### PR TITLE
Scheduled Rollups form two different child objects to same parent throws an error #802

### DIFF
--- a/force-app/main/classes/RollupService.cls
+++ b/force-app/main/classes/RollupService.cls
@@ -1214,6 +1214,7 @@ global with sharing class RollupService
 		// rollups that have not been updated/inserted after the insert/update enhancement is applied
 		// Unable to lower RelationShipCriteria__c because of field value case-(in)sensitivity configuration
 		return  (lookupWrapper.Lookup.ParentObject.toLowerCase() + '#' + 
+			     lookupWrapper.Lookup.ChildObject.toLowerCase() + '#' + 
 			     lookupWrapper.Lookup.RelationshipField.toLowerCase() + '#' + 
 			     lookupWrapper.Lookup.RelationShipCriteria + '#' + 
 			     rsfType + '#' + 


### PR DESCRIPTION
Scheduled Rollups form two different child objects to same parent throws an error if:

1. Sharing Mode is same for both rollups.
2. Relationship Field is same i.e. Relationship Field name is same from both child objects.
3. Relationship Criteria fields is same/null for both rollups.
4. rsfType is same for both.

Essentially, problem is coming from getContextKey method in RollupService class. Rollups from two different child objects returning same key. To fix this , I have made changes as follows and this seems to fix the problem. Do you see any problem with the fix.