### PR TITLE
Feature/integrate npsp tdtm

### DIFF
--- a/dlrs/main/classes/RollupController.cls
+++ b/dlrs/main/classes/RollupController.cls
@@ -215,8 +215,7 @@ public with sharing class RollupController {
           : ('        // Force the ' +
             RollupTriggerName +
             ' to be invoked, fails the test if org config or other Apex code prevents this.\n' +
-            '        Callable npspApi = (System.Callable)Type.forName(\'npsp\', \'Callable_API\').newInstance();\n' +
-            '        Boolean isNpspTriggerDisabled = (Boolean)npspApi.call(\'TDTM.DisableAllTriggers\', new Map<String, Object>());\n' +
+            '        RollupService.disableNpspTdtm();\n' +
             '        ' +
             (namespace.length() > 0 ? namespace + '.' : '') +
             'RollupService.testHandler(new ' +

--- a/dlrs/main/classes/RollupController.cls
+++ b/dlrs/main/classes/RollupController.cls
@@ -215,6 +215,8 @@ public with sharing class RollupController {
           : ('        // Force the ' +
             RollupTriggerName +
             ' to be invoked, fails the test if org config or other Apex code prevents this.\n' +
+            '        Callable npspApi = (System.Callable)Type.forName(\'npsp\', \'Callable_API\').newInstance();\n' +
+            '        Boolean isNpspTriggerDisabled = (Boolean)npspApi.call(\'TDTM.DisableAllTriggers\', new Map<String, Object>());\n' +
             '        ' +
             (namespace.length() > 0 ? namespace + '.' : '') +
             'RollupService.testHandler(new ' +

--- a/dlrs/main/classes/RollupControllerTest.cls
+++ b/dlrs/main/classes/RollupControllerTest.cls
@@ -227,6 +227,7 @@ private class RollupControllerTest {
         '        // Force the ' +
         controller.RollupTriggerName +
         ' to be invoked, fails the test if org config or other Apex code prevents this.\n' +
+        '        RollupService.disableNpspTdtm();\n' +
         '        ' +
         Utilities.classPrefix() +
         'RollupService.testHandler(new ' +

--- a/dlrs/main/classes/RollupService.cls
+++ b/dlrs/main/classes/RollupService.cls
@@ -1560,6 +1560,27 @@ global with sharing class RollupService {
   }
 
   /**
+   * Check if npsp is installed and TDTM can be disabled with Callable_API
+   **/
+  private static Boolean npspInstalled() {
+    if (Type.forName('npsp', 'Callable_API') != null) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * If possible, disable npsp tdtm triggers with Callable_API
+   **/
+  public static void disableNpspTdtm() {
+    if (!npspInstalled()) {
+      return;
+    }
+    Callable npspApi = (System.Callable) Type.forName('npsp', 'Callable_API').newInstance();
+    npspApi.call('TDTM.DisableAllTriggers', new Map<String, Object>());
+  }
+
+  /**
    * Wrapper around DML allowing with or without sharing to be applied and all or nothing exception handling
    **/
   private static List<Database.Saveresult> updateRecords(

--- a/dlrs/main/classes/RollupServiceTest.cls
+++ b/dlrs/main/classes/RollupServiceTest.cls
@@ -963,6 +963,9 @@ private with sharing class RollupServiceTest {
     if (!TestContext.isSupported())
       return;
 
+    // If NPSP is present, disable NPSP TDTM triggers. They distort the limit counts.
+    RollupService.disableNpspTdtm();
+
     // Disable the Account trigger for this test, its carefully caluculated test actuals are thrown when this is enabled as well
     TestContext.AccountTestTriggerEnabled = false;
 
@@ -1081,6 +1084,9 @@ private with sharing class RollupServiceTest {
     // Test supported?
     if (!TestContext.isSupported())
       return;
+
+    // If NPSP is present, disable NPSP TDTM triggers. They distort the limit counts.
+    RollupService.disableNpspTdtm();
 
     // Disable the Account trigger for this test, its carefully caluculated test actuals are thrown when this is enabled as well
     TestContext.AccountTestTriggerEnabled = false;


### PR DESCRIPTION
# Critical Changes

# Changes
Added methods RollupService.npspInstalled() and RollupService.disableNpspTdtm().  Add code to disable NPSP TDTM triggers during the deployment of test code.  Disabled NPSP TDTM triggers during the execution of RollupServiceTest.testLimitsConsumedWithConditions() and testLimitsConsumedWithoutConditions as the query counts were being impacted by TDTM.

# Issues Closed
