### PR TITLE
Feature: Amended error message on save/update to inform the user that you can't activate without deployment

### DIFF
--- a/dlrs/main/classes/MLRSControllerTest.cls
+++ b/dlrs/main/classes/MLRSControllerTest.cls
@@ -1,6 +1,58 @@
 @IsTest
 public with sharing class MLRSControllerTest {
   @IsTest
+  public static void has_both_triggers_present() {
+    if (!TestContext.isSupported()) {
+      return;
+    }
+    ManageLookupRollupSummariesController controller = new ManageLookupRollupSummariesController();
+    controller.LookupRollupSummary = testRollupData();
+    controller.hasChildTriggers();
+    System.assertEquals(
+      'Rollup has child and parent triggers deployed. Can activate',
+      Apexpages.getMessages()[0].getSummary(),
+      'Should return message indicating parent and child trigger are deployed'
+    );
+  }
+
+  @IsTest
+  public static void has_one_trigger_present() {
+    if (!TestContext.isSupported()) {
+      return;
+    }
+    ManageLookupRollupSummariesController controller = new ManageLookupRollupSummariesController();
+    LookupRollupSummary2__mdt noParent = testRollupData();
+    noParent.ParentObject__c = 'objectNotInDatabase';
+    controller.LookupRollupSummary = noParent;
+    controller.hasChildTriggers();
+
+    System.assertEquals(
+      'Rollup has only one trigger deployed. Cannot activate',
+      Apexpages.getMessages()[0].getSummary(),
+      'Should return message indicating only one trigger is deployed'
+    );
+  }
+
+  @IsTest
+  public static void has_no_trigger_present() {
+    if (!TestContext.isSupported()) {
+      return;
+    }
+    ManageLookupRollupSummariesController controller = new ManageLookupRollupSummariesController();
+    LookupRollupSummary2__mdt noTrigger = testRollupData();
+    noTrigger.ParentObject__c = 'objectNotInDatabase';
+    noTrigger.ChildObject__c = 'ChildObjectNotInDatabase';
+    controller.LookupRollupSummary = noTrigger;
+    controller.hasChildTriggers();
+
+    System.assertEquals(
+      'Rollup does not have any triggers deployed. Cannot activate',
+      Apexpages.getMessages()[0].getSummary(),
+      'Should return message indicating no triggers are deployed'
+    );
+  }
+
+  @IsTest
   public static void clone_on_id_parameter() {
     ManageLookupRollupSummariesController controller = new ManageLookupRollupSummariesController();
     Pagereference currentPage = Page.managelookuprollupsummaries;

--- a/dlrs/main/classes/ManageLookupRollupSummariesController.cls
+++ b/dlrs/main/classes/ManageLookupRollupSummariesController.cls
@@ -175,11 +175,10 @@ public with sharing class ManageLookupRollupSummariesController {
   }
 
   public void hasChildTriggers() {
-
-    if (LookupRollupSummary == null){
+    if (LookupRollupSummary == null) {
       return;
-    }else {
-    try {
+    } else {
+      try {
         RollupSummary rs = new RollupSummary(LookupRollupSummary);
         String childTrigger = RollupSummaries.makeTriggerName(rs);
         String parentTrigger = RollupSummaries.makeParentTriggerName(rs);
@@ -214,9 +213,9 @@ public with sharing class ManageLookupRollupSummariesController {
             );
           }
         }
-      
-    } catch (Exception e) { } 
-  }
+      } catch (Exception e) {
+      }
+    }
   }
 
   //TO cloneRollupSummary, we query the database for the rollup summary with passed cloneLookup,

--- a/dlrs/main/classes/ManageLookupRollupSummariesController.cls
+++ b/dlrs/main/classes/ManageLookupRollupSummariesController.cls
@@ -156,6 +156,28 @@ public with sharing class ManageLookupRollupSummariesController {
     return null;
   }
 
+  public void hasChildTriggers(){
+    if (LookupRollupSummary != null){
+      RollupSummary rs = new RollupSummary(LookupRollupSummary);
+      String childTrigger = RollupSummaries.makeTriggerName(rs);
+      String parentTrigger = RollupSummaries.makeParentTriggerName(rs);
+      ApexTriggersSelector selector = new ApexTriggersSelector();
+      Map<String, ApexTrigger> loadTriggers = selector.selectByName(new Set<String>{ChildTrigger, ParentTrigger});
+
+      switch on loadTriggers.size() {
+        when 2{
+          Apexpages.addMessage(new Apexpages.Message(Apexpages.severity.CONFIRM, 'Rollup has child and parent triggers deployed. Can activate'));
+        }
+        when 1{
+          Apexpages.addMessage(new Apexpages.Message(Apexpages.severity.warning, 'Rollup has only one trigger deployed. Cannot activate'));
+        }
+        when else{
+          Apexpages.addMessage(new Apexpages.Message(Apexpages.severity.fatal, 'Rollup does not have any triggers deployed. Cannot activate'));
+        }
+      }
+    }
+  }
+
   //TO cloneRollupSummary, we query the database for the rollup summary with passed cloneLookup,
   //then set clonesummary with empty values on known values to edit.
   public void cloneRollupSummary() {

--- a/dlrs/main/classes/ManageLookupRollupSummariesController.cls
+++ b/dlrs/main/classes/ManageLookupRollupSummariesController.cls
@@ -177,44 +177,45 @@ public with sharing class ManageLookupRollupSummariesController {
   public void hasChildTriggers() {
     if (LookupRollupSummary == null) {
       return;
-    } else {
-      try {
-        RollupSummary rs = new RollupSummary(LookupRollupSummary);
-        String childTrigger = RollupSummaries.makeTriggerName(rs);
-        String parentTrigger = RollupSummaries.makeParentTriggerName(rs);
-        ApexTriggersSelector selector = new ApexTriggersSelector();
-        Map<String, ApexTrigger> loadTriggers = selector.selectByName(
-          new Set<String>{ ChildTrigger, ParentTrigger }
-        );
+    }
+    try {
+      RollupSummary rs = new RollupSummary(LookupRollupSummary);
+      String childTrigger = RollupSummaries.makeTriggerName(rs);
+      String parentTrigger = RollupSummaries.makeParentTriggerName(rs);
+      ApexTriggersSelector selector = new ApexTriggersSelector();
+      Map<String, ApexTrigger> loadTriggers = selector.selectByName(
+        new Set<String>{ ChildTrigger, ParentTrigger }
+      );
 
-        switch on loadTriggers.size() {
-          when 2 {
-            Apexpages.addMessage(
-              new Apexpages.Message(
-                Apexpages.severity.CONFIRM,
-                'Rollup has child and parent triggers deployed. Can activate'
-              )
-            );
-          }
-          when 1 {
-            Apexpages.addMessage(
-              new Apexpages.Message(
-                Apexpages.severity.WARNING,
-                'Rollup has only one trigger deployed. Cannot activate'
-              )
-            );
-          }
-          when else {
-            Apexpages.addMessage(
-              new Apexpages.Message(
-                Apexpages.severity.FATAL,
-                'Rollup does not have any triggers deployed. Cannot activate'
-              )
-            );
-          }
+      switch on loadTriggers.size() {
+        when 2 {
+          Apexpages.addMessage(
+            new Apexpages.Message(
+              Apexpages.severity.CONFIRM,
+              'Rollup has child and parent triggers deployed. Can activate'
+            )
+          );
         }
-      } catch (Exception e) {
+        when 1 {
+          Apexpages.addMessage(
+            new Apexpages.Message(
+              Apexpages.severity.WARNING,
+              'Rollup has only one trigger deployed. Cannot activate'
+            )
+          );
+        }
+        when else {
+          Apexpages.addMessage(
+            new Apexpages.Message(
+              Apexpages.severity.FATAL,
+              'Rollup does not have any triggers deployed. Cannot activate'
+            )
+          );
+        }
       }
+    } catch (Exception e) {
+      //This method is intended to be informational.
+      //If it fails for some reason(soql query) it should not effect the functionality of the Visualforce Page.
     }
   }
 

--- a/dlrs/main/classes/ManageLookupRollupSummariesController.cls
+++ b/dlrs/main/classes/ManageLookupRollupSummariesController.cls
@@ -164,6 +164,7 @@ public with sharing class ManageLookupRollupSummariesController {
   }
 
   public void hasChildTriggers(){
+    try{
     if (LookupRollupSummary != null){
       RollupSummary rs = new RollupSummary(LookupRollupSummary);
       String childTrigger = RollupSummaries.makeTriggerName(rs);
@@ -182,6 +183,10 @@ public with sharing class ManageLookupRollupSummariesController {
           Apexpages.addMessage(new Apexpages.Message(Apexpages.severity.fatal, 'Rollup does not have any triggers deployed. Cannot activate'));
         }
       }
+    }
+    }catch(Exception e){
+      //ultimately if there is an error it should not effect the rollup summary functionality. Probably better to fail silently. 
+      Apexpages.addMessage(new Apexpages.Message(Apexpages.severity.info, e.getMessage()));
     }
   }
 

--- a/dlrs/main/classes/ManageLookupRollupSummariesController.cls
+++ b/dlrs/main/classes/ManageLookupRollupSummariesController.cls
@@ -79,7 +79,7 @@ public with sharing class ManageLookupRollupSummariesController {
           )
           .selectById(new Set<String>{ selectedLookup })[0]
         .Record;
-        hasChildTriggers();
+      hasChildTriggers();
     } else {
       selectedLookup = ApexPages.currentPage()
         .getParameters()
@@ -131,10 +131,22 @@ public with sharing class ManageLookupRollupSummariesController {
           );
         }
         for (String fieldError : recordError.FieldErrors) {
-          if (fieldError.contains(' has not been deployed')){
-            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, fieldError));
-            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.WARNING, 'You must deploy \'Child Triggers\' before activating Rollup Summary. Uncheck \'Active\' and save again. '));
-            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.WARNING, 'Once page reloads click \'Manage Child Triggers\' to deploy triggers. Then return to this page and check \'Active\' box. '));
+          if (fieldError.contains(' has not been deployed')) {
+            ApexPages.addMessage(
+              new ApexPages.Message(ApexPages.Severity.ERROR, fieldError)
+            );
+            ApexPages.addMessage(
+              new ApexPages.Message(
+                ApexPages.Severity.WARNING,
+                'You must deploy \'Child Triggers\' before activating Rollup Summary. Uncheck \'Active\' and save again. '
+              )
+            );
+            ApexPages.addMessage(
+              new ApexPages.Message(
+                ApexPages.Severity.WARNING,
+                'Once page reloads click \'Manage Child Triggers\' to deploy triggers. Then return to this page and check \'Active\' box. '
+              )
+            );
           }
           ApexPages.addMessage(
             new ApexPages.Message(ApexPages.Severity.Error, fieldError)
@@ -163,30 +175,49 @@ public with sharing class ManageLookupRollupSummariesController {
     return null;
   }
 
-  public void hasChildTriggers(){
-    try{
-    if (LookupRollupSummary != null){
-      RollupSummary rs = new RollupSummary(LookupRollupSummary);
-      String childTrigger = RollupSummaries.makeTriggerName(rs);
-      String parentTrigger = RollupSummaries.makeParentTriggerName(rs);
-      ApexTriggersSelector selector = new ApexTriggersSelector();
-      Map<String, ApexTrigger> loadTriggers = selector.selectByName(new Set<String>{ChildTrigger, ParentTrigger});
+  public void hasChildTriggers() {
+    try {
+      if (LookupRollupSummary != null) {
+        RollupSummary rs = new RollupSummary(LookupRollupSummary);
+        String childTrigger = RollupSummaries.makeTriggerName(rs);
+        String parentTrigger = RollupSummaries.makeParentTriggerName(rs);
+        ApexTriggersSelector selector = new ApexTriggersSelector();
+        Map<String, ApexTrigger> loadTriggers = selector.selectByName(
+          new Set<String>{ ChildTrigger, ParentTrigger }
+        );
 
-      switch on loadTriggers.size() {
-        when 2{
-          Apexpages.addMessage(new Apexpages.Message(Apexpages.severity.CONFIRM, 'Rollup has child and parent triggers deployed. Can activate'));
-        }
-        when 1{
-          Apexpages.addMessage(new Apexpages.Message(Apexpages.severity.warning, 'Rollup has only one trigger deployed. Cannot activate'));
-        }
-        when else{
-          Apexpages.addMessage(new Apexpages.Message(Apexpages.severity.fatal, 'Rollup does not have any triggers deployed. Cannot activate'));
+        switch on loadTriggers.size() {
+          when 2 {
+            Apexpages.addMessage(
+              new Apexpages.Message(
+                Apexpages.severity.CONFIRM,
+                'Rollup has child and parent triggers deployed. Can activate'
+              )
+            );
+          }
+          when 1 {
+            Apexpages.addMessage(
+              new Apexpages.Message(
+                Apexpages.severity.warning,
+                'Rollup has only one trigger deployed. Cannot activate'
+              )
+            );
+          }
+          when else {
+            Apexpages.addMessage(
+              new Apexpages.Message(
+                Apexpages.severity.fatal,
+                'Rollup does not have any triggers deployed. Cannot activate'
+              )
+            );
+          }
         }
       }
-    }
-    }catch(Exception e){
-      //ultimately if there is an error it should not effect the rollup summary functionality. Probably better to fail silently. 
-      Apexpages.addMessage(new Apexpages.Message(Apexpages.severity.info, e.getMessage()));
+    } catch (Exception e) {
+      //ultimately if there is an error it should not effect the rollup summary functionality. Probably better to fail silently.
+      Apexpages.addMessage(
+        new Apexpages.Message(Apexpages.severity.info, e.getMessage())
+      );
     }
   }
 

--- a/dlrs/main/classes/ManageLookupRollupSummariesController.cls
+++ b/dlrs/main/classes/ManageLookupRollupSummariesController.cls
@@ -79,7 +79,6 @@ public with sharing class ManageLookupRollupSummariesController {
           )
           .selectById(new Set<String>{ selectedLookup })[0]
         .Record;
-      hasChildTriggers();
     } else {
       selectedLookup = ApexPages.currentPage()
         .getParameters()
@@ -92,9 +91,9 @@ public with sharing class ManageLookupRollupSummariesController {
             .selectByDeveloperName(new Set<String>{ selectedLookup })[0]
           .Record;
         selectedLookup = LookupRollupSummary.Id;
-        hasChildTriggers();
       }
     }
+    hasChildTriggers();
     return null;
   }
 
@@ -176,8 +175,11 @@ public with sharing class ManageLookupRollupSummariesController {
   }
 
   public void hasChildTriggers() {
+
+    if (LookupRollupSummary == null){
+      return;
+    }else {
     try {
-      if (LookupRollupSummary != null) {
         RollupSummary rs = new RollupSummary(LookupRollupSummary);
         String childTrigger = RollupSummaries.makeTriggerName(rs);
         String parentTrigger = RollupSummaries.makeParentTriggerName(rs);
@@ -212,13 +214,9 @@ public with sharing class ManageLookupRollupSummariesController {
             );
           }
         }
-      }
-    } catch (Exception e) {
-      //ultimately if there is an error it should not effect the rollup summary functionality. Probably better to fail silently.
-      Apexpages.addMessage(
-        new Apexpages.Message(Apexpages.severity.info, e.getMessage())
-      );
-    }
+      
+    } catch (Exception e) { } 
+  }
   }
 
   //TO cloneRollupSummary, we query the database for the rollup summary with passed cloneLookup,

--- a/dlrs/main/classes/ManageLookupRollupSummariesController.cls
+++ b/dlrs/main/classes/ManageLookupRollupSummariesController.cls
@@ -79,6 +79,7 @@ public with sharing class ManageLookupRollupSummariesController {
           )
           .selectById(new Set<String>{ selectedLookup })[0]
         .Record;
+        hasChildTriggers();
     } else {
       selectedLookup = ApexPages.currentPage()
         .getParameters()
@@ -91,6 +92,7 @@ public with sharing class ManageLookupRollupSummariesController {
             .selectByDeveloperName(new Set<String>{ selectedLookup })[0]
           .Record;
         selectedLookup = LookupRollupSummary.Id;
+        hasChildTriggers();
       }
     }
     return null;
@@ -129,6 +131,11 @@ public with sharing class ManageLookupRollupSummariesController {
           );
         }
         for (String fieldError : recordError.FieldErrors) {
+          if (fieldError.contains(' has not been deployed')){
+            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, fieldError));
+            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.WARNING, 'You must deploy \'Child Triggers\' before activating Rollup Summary. Uncheck \'Active\' and save again. '));
+            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.WARNING, 'Once page reloads click \'Manage Child Triggers\' to deploy triggers. Then return to this page and check \'Active\' box. '));
+          }
           ApexPages.addMessage(
             new ApexPages.Message(ApexPages.Severity.Error, fieldError)
           );

--- a/dlrs/main/classes/ManageLookupRollupSummariesController.cls
+++ b/dlrs/main/classes/ManageLookupRollupSummariesController.cls
@@ -130,7 +130,7 @@ public with sharing class ManageLookupRollupSummariesController {
           );
         }
         for (String fieldError : recordError.FieldErrors) {
-          if (fieldError.contains(' has not been deployed')) {
+          if (fieldError.contains('Active')) {
             ApexPages.addMessage(
               new ApexPages.Message(ApexPages.Severity.ERROR, fieldError)
             );
@@ -199,7 +199,7 @@ public with sharing class ManageLookupRollupSummariesController {
           when 1 {
             Apexpages.addMessage(
               new Apexpages.Message(
-                Apexpages.severity.warning,
+                Apexpages.severity.WARNING,
                 'Rollup has only one trigger deployed. Cannot activate'
               )
             );
@@ -207,7 +207,7 @@ public with sharing class ManageLookupRollupSummariesController {
           when else {
             Apexpages.addMessage(
               new Apexpages.Message(
-                Apexpages.severity.fatal,
+                Apexpages.severity.FATAL,
                 'Rollup does not have any triggers deployed. Cannot activate'
               )
             );


### PR DESCRIPTION
I added the features outline in issue #1123. Attached are screenshots of how it looks when a user saves a record(create/update) and when a user loads a record.
# Changes
-Amended the error message on save/update to inform the user that you can't activate a DLRS until the child trigger is deployed. And the "Active" checkbox needs to be unchecked when saving in this scenario.

Added a message on record load to make it clear if a trigger has been deployed or not:
1. Success(Green) indicator child and parent triggers are deployed.
2. Warning(orange) indicator if only a child or parent trigger is deployed.
3. Error(Red) indicator if neither child or parent trigger is deployed.

# Issues Closed
In response to #1123

#Screenshots 
![Load - success](https://user-images.githubusercontent.com/20290118/165770666-491124f2-22b8-46d3-bfab-1b191195b86f.JPG)
![Load - Warning](https://user-images.githubusercontent.com/20290118/165770670-8b1bc54e-d837-4899-9c1f-6965d757cae4.JPG)
![Load - error](https://user-images.githubusercontent.com/20290118/165770671-81e46366-813c-4bfd-a2cd-ea334ad4e8a1.JPG)
![Save or Update - Cannot activate error](https://user-images.githubusercontent.com/20290118/165770672-a5463e1d-a2f4-43cd-a9b5-46ccfde6cbf7.JPG)
