### PR TITLE
Feature/apex scheduled #1126 Display on the new wizard if the apex is scheduled and what the schedule is

### DIFF
--- a/dlrs/main/classes/CronTriggersSelector.cls
+++ b/dlrs/main/classes/CronTriggersSelector.cls
@@ -28,4 +28,19 @@ public with sharing class CronTriggersSelector extends fflib_SObjectSelector {
 
     return ct;
   }
+
+  public List<CronTrigger> selectScheduledApexById(String id) {
+    id = '%' + id + '%';
+
+    List<CronTrigger> ct = Database.query(
+      newQueryFactory()
+        .selectfield('CronJobDetail.Name')
+        .setCondition('CronJobDetail.JobType = \'7\'')
+        .setCondition('CronJobDetail.Name LIKE :id')
+        .setLimit(1)
+        .tosoql()
+    );
+
+    return ct;
+  }
 }

--- a/dlrs/main/classes/MLRSControllerTest.cls
+++ b/dlrs/main/classes/MLRSControllerTest.cls
@@ -24,9 +24,9 @@ public with sharing class MLRSControllerTest {
   public static void get_schedule_if_null_id() {
     ManageLookupRollupSummariesController controller = new ManageLookupRollupSummariesController();
     System.assertEquals(
-      'No Schedule for Rollup - id null',
+      'No Schedule for Rollup',
       controller.getRollupSchedule(),
-      'Null lookupRollupSummary id should return string'
+      'Null lookupRollupSummary id should return string: No Schedule for Rollup'
     );
   }
 
@@ -38,9 +38,27 @@ public with sharing class MLRSControllerTest {
     System.assertEquals(
       'No Schedule for Rollup',
       controller.getRollupSchedule(),
-      'Empty SOQL query lookupRollupSummary should return string'
+      'Empty SOQL query lookupRollupSummary should return string: No Schedule for Rollup'
     );
   }
+
+  @IsTest
+  public static void get_schedule_if_caught_error() {
+    ManageLookupRollupSummariesController controller = new ManageLookupRollupSummariesController();
+    controller.LookupRollupSummary = testRollupData();
+
+    try {
+      controller.LookupRollupSummary.id = 'BadRecordID';
+      controller.getRollupSchedule();
+    } catch (Exception e) {
+      System.assertEquals(
+        'No Schedule for Rollup',
+        controller.getRollupSchedule(),
+        'should return string on error: No Schedule for Rollup'
+      );
+    }
+  }
+
   @IsTest
   public static void has_both_triggers_present() {
     if (!TestContext.isSupported()) {

--- a/dlrs/main/classes/MLRSControllerTest.cls
+++ b/dlrs/main/classes/MLRSControllerTest.cls
@@ -1,6 +1,47 @@
 @IsTest
 public with sharing class MLRSControllerTest {
   @IsTest
+  public static void get_next_scheduled_time() {
+    ManageLookupRollupSummariesController controller = new ManageLookupRollupSummariesController();
+    String sch = '20 30 8 10 2 ?';
+    String expectedDate = '2/10/2023, 8:30 AM';
+    Id scheduleID = 'm007A0000000Ua6QAE';
+    System.schedule(scheduleID.to15(), sch, new mockSchedule());
+    controller.LookupRollupSummary = testrollupdata();
+
+    Test.startTest();
+    String resultDate = controller.getRollupSchedule();
+    Test.stopTest();
+
+    system.assertEquals(
+      resultDate,
+      expectedDate,
+      'Should correctly pull schedule from string'
+    );
+  }
+
+  @IsTest
+  public static void get_schedule_if_null_id() {
+    ManageLookupRollupSummariesController controller = new ManageLookupRollupSummariesController();
+    System.assertEquals(
+      'No Schedule for Rollup - id null',
+      controller.getRollupSchedule(),
+      'Null lookupRollupSummary id should return string'
+    );
+  }
+
+  @IsTest
+  public static void get_schedule_if_empty_query_return() {
+    ManageLookupRollupSummariesController controller = new ManageLookupRollupSummariesController();
+    controller.LookupRollupSummary = testRollupData();
+
+    System.assertEquals(
+      'No Schedule for Rollup',
+      controller.getRollupSchedule(),
+      'Empty SOQL query lookupRollupSummary should return string'
+    );
+  }
+  @IsTest
   public static void has_both_triggers_present() {
     if (!TestContext.isSupported()) {
       return;
@@ -138,5 +179,11 @@ public with sharing class MLRSControllerTest {
     rollupSummaryA.TestCodeSeeAllData__c = false;
 
     return rollupSummaryA;
+  }
+
+  public class MockSchedule implements Schedulable {
+    public void execute(SchedulableContext sc) {
+      String test = 'nothingToExecute';
+    }
   }
 }

--- a/dlrs/main/classes/MLRSControllerTest.cls
+++ b/dlrs/main/classes/MLRSControllerTest.cls
@@ -34,7 +34,6 @@ public with sharing class MLRSControllerTest {
   public static void get_schedule_if_empty_query_return() {
     ManageLookupRollupSummariesController controller = new ManageLookupRollupSummariesController();
     controller.LookupRollupSummary = testRollupData();
-
     System.assertEquals(
       'No Schedule for Rollup',
       controller.getRollupSchedule(),

--- a/dlrs/main/classes/ManageLookupRollupSummariesController.cls
+++ b/dlrs/main/classes/ManageLookupRollupSummariesController.cls
@@ -219,7 +219,6 @@ public with sharing class ManageLookupRollupSummariesController {
     }
   }
 
-  //add contrigger to selector layer
   public String getRollupSchedule() {
     if (LookupRollupSummary.id == null) {
       return 'No Schedule for Rollup';

--- a/dlrs/main/classes/ManageLookupRollupSummariesController.cls
+++ b/dlrs/main/classes/ManageLookupRollupSummariesController.cls
@@ -221,7 +221,7 @@ public with sharing class ManageLookupRollupSummariesController {
 
   public String getRollupSchedule() {
     if (LookupRollupSummary.id == null) {
-      return 'No Schedule for Rollup';
+      return 'No Schedule for Rollup - id null';
     } else {
       try {
         String id = (LookupRollupSummary.id).to15();
@@ -241,7 +241,7 @@ public with sharing class ManageLookupRollupSummariesController {
           return ct[0].NextFireTime.format();
         }
       } catch (Exception e) {
-        return 'No Schedule for Rollup';
+        return 'Cannot Find Apex Scheduled Job';
       }
     }
   }

--- a/dlrs/main/classes/ManageLookupRollupSummariesController.cls
+++ b/dlrs/main/classes/ManageLookupRollupSummariesController.cls
@@ -219,6 +219,33 @@ public with sharing class ManageLookupRollupSummariesController {
     }
   }
 
+  public String getRollupSchedule() {
+    if (LookupRollupSummary.id == null) {
+      return 'No Schedule for Rollup - id null';
+    } else {
+      try {
+        String id = (LookupRollupSummary.id).to15();
+        id = '%' + id + '%';
+
+        List<CronTrigger> ct = [
+          SELECT CronJobDetail.Name, NextFireTime
+          FROM CronTrigger
+          WHERE CronJobDetail.Name LIKE :id
+          WITH SECURITY_ENFORCED
+          LIMIT 1
+        ];
+
+        if (ct.isEmpty()) {
+          return 'No Schedule for Rollup';
+        } else {
+          return ct[0].NextFireTime.format();
+        }
+      } catch (Exception e) {
+        return 'Cannot Find Apex Scheduled Job';
+      }
+    }
+  }
+
   //TO cloneRollupSummary, we query the database for the rollup summary with passed cloneLookup,
   //then set clonesummary with empty values on known values to edit.
   public void cloneRollupSummary() {

--- a/dlrs/main/classes/ManageLookupRollupSummariesController.cls
+++ b/dlrs/main/classes/ManageLookupRollupSummariesController.cls
@@ -219,30 +219,24 @@ public with sharing class ManageLookupRollupSummariesController {
     }
   }
 
+  //add contrigger to selector layer
   public String getRollupSchedule() {
     if (LookupRollupSummary.id == null) {
       return 'No Schedule for Rollup';
-    } else {
-      try {
-        String id = (LookupRollupSummary.id).to15();
-        id = '%' + id + '%';
+    }
 
-        List<CronTrigger> ct = [
-          SELECT CronJobDetail.Name, NextFireTime
-          FROM CronTrigger
-          WHERE CronJobDetail.Name LIKE :id
-          WITH SECURITY_ENFORCED
-          LIMIT 1
-        ];
+    try {
+      String id = (LookupRollupSummary.id).to15();
+      List<CronTrigger> ct = new CronTriggersSelector()
+        .selectScheduledApexById(id);
 
-        if (ct.isEmpty()) {
-          return 'No Schedule for Rollup';
-        } else {
-          return ct[0].NextFireTime.format();
-        }
-      } catch (Exception e) {
+      if (ct.isEmpty()) {
         return 'No Schedule for Rollup';
+      } else {
+        return ct[0].NextFireTime.format();
       }
+    } catch (Exception e) {
+      return 'No Schedule for Rollup';
     }
   }
 

--- a/dlrs/main/classes/ManageLookupRollupSummariesController.cls
+++ b/dlrs/main/classes/ManageLookupRollupSummariesController.cls
@@ -221,7 +221,7 @@ public with sharing class ManageLookupRollupSummariesController {
 
   public String getRollupSchedule() {
     if (LookupRollupSummary.id == null) {
-      return 'No Schedule for Rollup - id null';
+      return 'No Schedule for Rollup';
     } else {
       try {
         String id = (LookupRollupSummary.id).to15();
@@ -241,7 +241,7 @@ public with sharing class ManageLookupRollupSummariesController {
           return ct[0].NextFireTime.format();
         }
       } catch (Exception e) {
-        return 'Cannot Find Apex Scheduled Job';
+        return 'No Schedule for Rollup';
       }
     }
   }

--- a/dlrs/main/pages/managelookuprollupsummaries.page
+++ b/dlrs/main/pages/managelookuprollupsummaries.page
@@ -22,7 +22,7 @@
 			<apex:pageBlock mode="edit" id="rollupDetailView">
 				<apex:pageBlockButtons>
 					<apex:commandButton value="Save" action="{!save}" />
-					<apex:commandButton value="Clone" action="{!clonex}"  rendered="{!LookupRollupSummary.Id!=null}" />
+					<apex:commandButton value="Clone" action="{!clonex}" rendered="{!LookupRollupSummary.Id!=null}" />
 					<apex:commandButton value="Delete" action="{!deleteX}" rendered="{!LookupRollupSummary.Id!=null}" />
 					<apex:commandButton value="Full Calculate" action="{!URLFOR($Page.rollupcalculatemdt, null, ['id'=LookupRollupSummary.id])}"
 					 rendered="{!LookupRollupSummary.Id!=null}" />
@@ -160,6 +160,13 @@
 						<apex:inputText value="{!LookupRollupSummary.RowLimit__c}" />
 					</apex:pageBlockSectionItem>
 				</apex:pageBlockSection>
+				<apex:pageBlockSectionItem rendered="{!LookupRollupSummary.Id!=null}">
+					<apex:outputLabel value="Scheduled Apex - Next Trigger Date:" />
+					<apex:outputPanel>
+						<apex:outputText style="font-style:italic;color:green" value="{!RollupSchedule}" rendered="{!LookupRollupSummary.Id!=null}">
+						</apex:outputText>
+					</apex:outputPanel>
+				</apex:pageBlockSectionItem>
 				<apex:pageBlockSection title="Text Lookups" columns="2">
 					<apex:pageBlockSectionItem helpText="{!$ObjectType.LookupRollupSummary2__mdt.fields.ConcatenateDelimiter__c.inlineHelpText}">
 						<apex:outputLabel value="{!$ObjectType.LookupRollupSummary2__mdt.fields.ConcatenateDelimiter__c.Label}" />

--- a/dlrs/main/pages/managelookuprollupsummaries.page
+++ b/dlrs/main/pages/managelookuprollupsummaries.page
@@ -160,13 +160,15 @@
 						<apex:inputText value="{!LookupRollupSummary.RowLimit__c}" />
 					</apex:pageBlockSectionItem>
 				</apex:pageBlockSection>
-				<apex:pageBlockSectionItem rendered="{!LookupRollupSummary.Id!=null}">
-					<apex:outputLabel value="Scheduled Apex - Next Trigger Date:" />
-					<apex:outputPanel>
-						<apex:outputText style="font-style:italic;color:green" value="{!RollupSchedule}" rendered="{!LookupRollupSummary.Id!=null}">
-						</apex:outputText>
-					</apex:outputPanel>
-				</apex:pageBlockSectionItem>
+				<apex:pageBlockSection>
+					<apex:pageBlockSectionItem rendered="{!LookupRollupSummary.Id!=null}">
+						<apex:outputLabel value="Scheduled Apex - Next Trigger Date:" />
+						<apex:outputPanel>
+							<apex:outputText style="font-style:italic;color:green" value="{!RollupSchedule}" rendered="{!LookupRollupSummary.Id!=null}">
+							</apex:outputText>
+						</apex:outputPanel>
+					</apex:pageBlockSectionItem>
+				</apex:pageBlockSection>
 				<apex:pageBlockSection title="Text Lookups" columns="2">
 					<apex:pageBlockSectionItem helpText="{!$ObjectType.LookupRollupSummary2__mdt.fields.ConcatenateDelimiter__c.inlineHelpText}">
 						<apex:outputLabel value="{!$ObjectType.LookupRollupSummary2__mdt.fields.ConcatenateDelimiter__c.Label}" />

--- a/dlrs/main/pages/managelookuprollupsummaries.page
+++ b/dlrs/main/pages/managelookuprollupsummaries.page
@@ -159,12 +159,12 @@
 						<apex:outputLabel value="{!$ObjectType.LookupRollupSummary2__mdt.fields.RowLimit__c.Label}" />
 						<apex:inputText value="{!LookupRollupSummary.RowLimit__c}" />
 					</apex:pageBlockSectionItem>
-				</apex:pageBlockSection>
-				<apex:pageBlockSection>
-					<apex:pageBlockSectionItem rendered="{!LookupRollupSummary.Id!=null}">
-						<apex:outputLabel value="Scheduled Apex - Next Trigger Date:" />
-						<apex:outputPanel>
-							<apex:outputText style="font-style:italic;color:green" value="{!RollupSchedule}" rendered="{!LookupRollupSummary.Id!=null}">
+					<apex:pageBlockSectionItem>
+						<apex:outputPanel style="font-weight: bold; margin-left: 150px; ">
+							<apex:outputLabel value="Scheduled Full Calculate - Next Date:" rendered="{!LookupRollupSummary.Id!=null}" />
+							<apex:outputText style="color:red" value="{!RollupSchedule}" rendered="{!LookupRollupSummary.Id!=null && RollupSchedule='No Schedule for Rollup'}">
+							</apex:outputText>
+							<apex:outputText style="color:green" value="{!RollupSchedule}" rendered="{!LookupRollupSummary.Id!=null && RollupSchedule !='No Schedule for Rollup'}">
 							</apex:outputText>
 						</apex:outputPanel>
 					</apex:pageBlockSectionItem>

--- a/dlrs/main/pages/managelookuprollupsummaries.page
+++ b/dlrs/main/pages/managelookuprollupsummaries.page
@@ -159,12 +159,12 @@
 						<apex:outputLabel value="{!$ObjectType.LookupRollupSummary2__mdt.fields.RowLimit__c.Label}" />
 						<apex:inputText value="{!LookupRollupSummary.RowLimit__c}" />
 					</apex:pageBlockSectionItem>
-					<apex:pageBlockSectionItem>
-						<apex:outputPanel style="font-weight: bold; margin-left: 150px; ">
-							<apex:outputLabel value="Scheduled Full Calculate - Next Date:" rendered="{!LookupRollupSummary.Id!=null}" />
-							<apex:outputText style="color:red" value="{!RollupSchedule}" rendered="{!LookupRollupSummary.Id!=null && RollupSchedule='No Schedule for Rollup'}">
-							</apex:outputText>
-							<apex:outputText style="color:green" value="{!RollupSchedule}" rendered="{!LookupRollupSummary.Id!=null && RollupSchedule !='No Schedule for Rollup'}">
+				</apex:pageBlockSection>
+				<apex:pageBlockSection>
+					<apex:pageBlockSectionItem rendered="{!LookupRollupSummary.Id!=null}">
+						<apex:outputLabel value="Scheduled Apex - Next Trigger Date:" />
+						<apex:outputPanel>
+							<apex:outputText style="font-style:italic;color:green" value="{!RollupSchedule}" rendered="{!LookupRollupSummary.Id!=null}">
 							</apex:outputText>
 						</apex:outputPanel>
 					</apex:pageBlockSectionItem>


### PR DESCRIPTION
I worked with @boopathiking1154 on this pull request to complete issue #1126. As the new wizard does not currently have edit capabilities, we added this feature to the current rollup wizard. Issue #1126 also asks for a view list of all scheduled rollups that has been added in #1131/#1183. 

# Changes
Added field on Manage Lookup Rollup Summaries page "Scheduled Full Calculate - Next Date". This field returns the date of the next scheduled full calculate as a timestamp, if the end user has initiated a scheduled full calculate for the rollup summary. 

- Returns value as green text if schedule is found
- Returns value as red text if schedule is not found with message "No Schedule for Rollup".


# Issues Closed
#1126 

![date for future schedule](https://user-images.githubusercontent.com/20290118/167701531-1cf14249-af9b-496e-992a-f95c552b0b5e.JPG)
![No date for schedule](https://user-images.githubusercontent.com/20290118/167701537-022f2747-7fa9-4ed1-bcdc-ebb35cbb7ad1.JPG)
