### PR TITLE
UI feedback

### DIFF
--- a/dlrs/main/pages/managelookuprollupsummaries.page
+++ b/dlrs/main/pages/managelookuprollupsummaries.page
@@ -162,7 +162,7 @@
 					<apex:pageBlockSectionItem>
 						<apex:outputPanel style="font-weight: bold; margin-left: 150px; ">
 							<apex:outputLabel value="Scheduled Full Calculate - Next Date:" rendered="{!LookupRollupSummary.Id!=null}" />
-							<apex:outputText style="color:red" value="{!RollupSchedule}" rendered="{!LookupRollupSummary.Id!=null && RollupSchedule='No Schedule for Rollup'}">
+							<apex:outputText style="color:rgba(255, 166, 0, 0.589)" value="{!RollupSchedule}" rendered="{!LookupRollupSummary.Id!=null && RollupSchedule='No Schedule for Rollup'}">
 							</apex:outputText>
 							<apex:outputText style="color:green" value="{!RollupSchedule}" rendered="{!LookupRollupSummary.Id!=null && RollupSchedule !='No Schedule for Rollup'}">
 							</apex:outputText>


### PR DESCRIPTION
@afawcett - Schedule Full Calculate: shows red text no schedule for rollup (though it does qualify “full” calculate - suggest making this text orangage or some “warning” level indicator)

# Changes
Feedback from Andrew to change color of full calculate to orange. 

#Screenshot
![beige color](https://user-images.githubusercontent.com/20290118/173705384-958dfab0-3690-4c08-8545-f25d74cab4dd.PNG)
