### PR TITLE
Updated "Lookup Rollup List View" with changes from feedback

### DIFF
--- a/dlrs/main/classes/RollupSummaryViewController.cls
+++ b/dlrs/main/classes/RollupSummaryViewController.cls
@@ -67,7 +67,7 @@ public with sharing class RollupSummaryViewController {
       String id = c.CronJobDetail.Name.substringBetween('(', ')');
       if (viewerRecords.containsKey(id)) {
         viewerRecords.get(id).apexJobName = c.CronJobDetail.Name;
-        viewerRecords.get(id).scheduledTime = c.CronExpression;
+        viewerRecords.get(id).scheduledTime = c.NextFireTime.format();
         viewerRecords.get(id).jobFiredCount = c.TimesTriggered;
       }
     }

--- a/dlrs/main/classes/RollupSummaryViewControllerTest.cls
+++ b/dlrs/main/classes/RollupSummaryViewControllerTest.cls
@@ -180,8 +180,8 @@ private class RollupSummaryViewControllerTest {
   }
 
   private static List<CronTrigger> testCronTriggerData() {
-    String jsonCronTrigger1 = '{ "CronTrigger" : { "id": "08e7A00000SlgHHQAZ", "TimesTriggered" : 0, "State":"WAITING", "CronJobDetailId": "08a7A00000SlsJYQAZ", "CronExpression": "0 3 2 * * ?", "CronJobDetail" : {"Id":"08a7A00000SlsJYQAZ","Name":"rollup_test10 (m007A0000000Ua6)"} } }';
-    String jsonCronTrigger2 = '{ "CronTrigger" : { "id": "08e7A00000SlgBnQAJ", "TimesTriggered" : 0, "State":"WAITING", "CronJobDetailId": "08a7A00000SlsE4QAJ", "CronExpression": "0 3 2 * * ?", "CronJobDetail" : {"Id":"08a7A00000SlsE4QAJ","Name":"rollup_test11 (m007A0000000UaB)"} } }';
+    String jsonCronTrigger1 = '{ "CronTrigger" : { "id": "08e7A00000SlgHHQAZ", "TimesTriggered" : 0, "State":"WAITING", "NextFireTime": "2030-10-30T15:27:02.000Z", "CronExpression": "0 3 2 * * ?", "CronJobDetail" : {"Id":"08a7A00000SlsJYQAZ","Name":"rollup_test10 (m007A0000000Ua6)"} } }';
+    String jsonCronTrigger2 = '{ "CronTrigger" : { "id": "08e7A00000SlgBnQAJ", "TimesTriggered" : 0, "State":"WAITING", "NextFireTime": "2030-10-30T15:27:02.000Z", "CronExpression": "0 3 2 * * ?", "CronJobDetail" : {"Id":"08a7A00000SlsE4QAJ","Name":"rollup_test11 (m007A0000000UaB)"} } }';
 
     CronTrigger ct1 = (CronTrigger) JSON.deserialize(
       jsonCronTrigger1,

--- a/dlrs/main/pages/RollupSummaryView.page
+++ b/dlrs/main/pages/RollupSummaryView.page
@@ -1,10 +1,10 @@
 <apex:page controller="RollupSummaryViewController" lightningStylesheets="true" showHeader="true" sidebar="true">
-    <apex:pageBlock title="List View - Rollups With Scheduled Apex Jobs">
+    <apex:pageBlock title="List View - All Rollup Lookup Summaries">
         <apex:pageBlockTable value="{!view }" var="v">
             <apex:column headerValue="Rollup Label" value="{! v.label }" />
             <apex:column headerValue="Calculation Mode" value="{! v.calcMode }" />
             <apex:column headerValue="Scheduled Apex Job name (Empty = none)" value="{! v.apexJobName }" />
-            <apex:column headerValue="Scheduled to run Time" value="{! v.ScheduledTime }" />
+            <apex:column headerValue="Scheduled Full Calculate - Next Date" value="{! v.ScheduledTime }" />
             <apex:column headerValue="Job Fired Count" value="{! v.JobFiredCount }" />
             <apex:column headerValue="Record ID">
                 <apex:form>

--- a/dlrs/main/pages/RollupSummaryView.page
+++ b/dlrs/main/pages/RollupSummaryView.page
@@ -1,5 +1,5 @@
 <apex:page controller="RollupSummaryViewController" lightningStylesheets="true" showHeader="true" sidebar="true">
-    <apex:pageBlock title="List View - All Rollup Lookup Summaries">
+    <apex:pageBlock title="List View - All Lookup Rollup Summaries">
         <apex:pageBlockTable value="{!view }" var="v">
             <apex:column headerValue="Rollup Label" value="{! v.label }" />
             <apex:column headerValue="Calculation Mode" value="{! v.calcMode }" />


### PR DESCRIPTION
# Changes
I changed the "Lookup Rollup List View" from the feedback from @afawcett.

- Renamed the title to "List View - All Lookup Rollup Summaries" indicating that the tab shows all rollups - not just scheduled rollups.
- Changed the "scheduled to run time" to "SCHEDULED FULL CALCULATE - NEXT DATE" with date formatted in the users local time.

# Issues Closed
![visuals](https://user-images.githubusercontent.com/20290118/175024757-4847d5dd-ac68-4073-a0b0-c618b9e85a82.PNG)