### PR TITLE
UI - error prompt feedback changes

### DIFF
--- a/dlrs/main/classes/MLRSControllerTest.cls
+++ b/dlrs/main/classes/MLRSControllerTest.cls
@@ -67,7 +67,7 @@ public with sharing class MLRSControllerTest {
     controller.LookupRollupSummary = testRollupData();
     controller.hasChildTriggers();
     System.assertEquals(
-      'Rollup has child and parent triggers deployed. Can activate',
+      'Rollup has child and parent triggers deployed.',
       Apexpages.getMessages()[0].getSummary(),
       'Should return message indicating parent and child trigger are deployed'
     );
@@ -85,7 +85,7 @@ public with sharing class MLRSControllerTest {
     controller.hasChildTriggers();
 
     System.assertEquals(
-      'Rollup has only one trigger deployed. Cannot activate',
+      'Rollup has only one trigger deployed.',
       Apexpages.getMessages()[0].getSummary(),
       'Should return message indicating only one trigger is deployed'
     );
@@ -104,7 +104,7 @@ public with sharing class MLRSControllerTest {
     controller.hasChildTriggers();
 
     System.assertEquals(
-      'Rollup does not have any triggers deployed. Cannot activate',
+      'Rollup does not have any triggers deployed.',
       Apexpages.getMessages()[0].getSummary(),
       'Should return message indicating no triggers are deployed'
     );

--- a/dlrs/main/classes/ManageLookupRollupSummariesController.cls
+++ b/dlrs/main/classes/ManageLookupRollupSummariesController.cls
@@ -134,16 +134,17 @@ public with sharing class ManageLookupRollupSummariesController {
             ApexPages.addMessage(
               new ApexPages.Message(ApexPages.Severity.ERROR, fieldError)
             );
+
             ApexPages.addMessage(
               new ApexPages.Message(
-                ApexPages.Severity.WARNING,
-                'You must deploy \'Child Triggers\' before activating Rollup Summary. Uncheck \'Active\' and save again. '
+                ApexPages.Severity.INFO,
+                'You must deploy \'Child Triggers\' before activating Lookup Rollup Summary.'
               )
             );
             ApexPages.addMessage(
               new ApexPages.Message(
-                ApexPages.Severity.WARNING,
-                'Once page reloads click \'Manage Child Triggers\' to deploy triggers. Then return to this page and check \'Active\' box. '
+                ApexPages.Severity.INFO,
+                'Click \'Manage Child Trigger\' to deploy triggers. Then return to this page and check \'Active\' box. '
               )
             );
           }
@@ -178,7 +179,16 @@ public with sharing class ManageLookupRollupSummariesController {
     if (LookupRollupSummary == null) {
       return;
     }
+
     try {
+      //quickly return if user does not want prompts or rollup is already active
+      if (
+        LookupRollupSummary.Active__c == true ||
+        DeclarativeLookupRollupSummaries__c.getOrgDefaults()
+          .HideManageLookupRollupSummariesInfo__c == true
+      ) {
+        return;
+      }
       RollupSummary rs = new RollupSummary(LookupRollupSummary);
       String childTrigger = RollupSummaries.makeTriggerName(rs);
       String parentTrigger = RollupSummaries.makeParentTriggerName(rs);
@@ -192,23 +202,23 @@ public with sharing class ManageLookupRollupSummariesController {
           Apexpages.addMessage(
             new Apexpages.Message(
               Apexpages.severity.CONFIRM,
-              'Rollup has child and parent triggers deployed. Can activate'
+              'Rollup has child and parent triggers deployed.'
             )
           );
         }
         when 1 {
           Apexpages.addMessage(
             new Apexpages.Message(
-              Apexpages.severity.WARNING,
-              'Rollup has only one trigger deployed. Cannot activate'
+              Apexpages.severity.INFO,
+              'Rollup has only one trigger deployed.'
             )
           );
         }
         when else {
           Apexpages.addMessage(
             new Apexpages.Message(
-              Apexpages.severity.FATAL,
-              'Rollup does not have any triggers deployed. Cannot activate'
+              Apexpages.severity.INFO,
+              'Rollup does not have any triggers deployed.'
             )
           );
         }


### PR DESCRIPTION
# Changes
Feedback changes from @afawcett testing document.

- Added the ability to toggle the informational messages on/off. 
- Added logic to hide messages if the rollup is already active.
- Changed warning level to indicate that the message as informational

# Issues Closed
![active](https://user-images.githubusercontent.com/20290118/175038056-97d85db9-1a0f-4541-9864-ef1f01ef2aa7.PNG)
![hide messages](https://user-images.githubusercontent.com/20290118/175038057-0b4065db-dda5-49f2-be0b-43e4dac955d9.PNG)
![non-active but triggers deployed](https://user-images.githubusercontent.com/20290118/175038058-f27796bc-fa35-4f37-b2e9-9082d1474f58.PNG)
![nonactive](https://user-images.githubusercontent.com/20290118/175038061-a2c08f69-0a1d-417a-bd84-e2422978e968.PNG)
