### PR TITLE
Cron Trigger selector skip deleted jobs

### DIFF
--- a/dlrs/main/classes/CronTriggersSelector.cls
+++ b/dlrs/main/classes/CronTriggersSelector.cls
@@ -19,10 +19,12 @@ public with sharing class CronTriggersSelector extends fflib_SObjectSelector {
   }
 
   public List<CronTrigger> selectAllScheduledApex() {
+    List<String> omittedStates = new List<String>{'DELETED'};
+
     List<CronTrigger> ct = Database.query(
       newQueryFactory()
         .selectfield('CronJobDetail.Name')
-        .setCondition('CronJobDetail.JobType = \'7\'')
+        .setCondition('CronJobDetail.JobType = \'7\' AND State NOT IN :omittedStates')
         .tosoql()
     );
 
@@ -35,8 +37,7 @@ public with sharing class CronTriggersSelector extends fflib_SObjectSelector {
     List<CronTrigger> ct = Database.query(
       newQueryFactory()
         .selectfield('CronJobDetail.Name')
-        .setCondition('CronJobDetail.JobType = \'7\'')
-        .setCondition('CronJobDetail.Name LIKE :id')
+        .setCondition('CronJobDetail.JobType = \'7\' AND CronJobDetail.Name LIKE :id')
         .setLimit(1)
         .tosoql()
     );


### PR DESCRIPTION
# Critical Changes
None

# Changes
- Deleted Cron Triggers are filtered out in selectAll
-  Cron triggers select by Id is returning Scheduled Apex jobs only

# Issues Closed
[#1253]