### PR TITLE
Rollup should only execute DML if it would change the parent's value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Salesforce DX and LWC local dev server cache
 .sfdx/
+.sf/
 .localdevserver/
 
 # DevOps
@@ -9,7 +10,7 @@ test_results.*
 src
 
 # Visual Studio Code
-.vscode 
+.vscode
 
 # LWC VSCode autocomplete
 **/lwc/jsconfig.json

--- a/dlrs/main/classes/RollupService.cls
+++ b/dlrs/main/classes/RollupService.cls
@@ -558,7 +558,11 @@ global with sharing class RollupService {
 
     // Update master records
     List<LookupRollupSummaryLog__c> rollupSummaryLogs = new List<LookupRollupSummaryLog__c>();
-    List<SObject> masterRecordList = masterRecords.values();
+
+    List<SObject> masterRecordList = getOnlyRecordsNeedingDml(
+      engineCtxByParentRelationship,
+      masterRecords
+    );
     List<Database.Saveresult> saveResults = updateRecords(
       masterRecordList,
       false,
@@ -1159,7 +1163,7 @@ global with sharing class RollupService {
   }
 
   /**
-   * Method wraps the LREngine.rolup method, provides context via the lookups described in RollupSummary
+   * Method wraps the LREngine.rollup method, provides context via the lookups described in RollupSummary
    *
    * @param lookups Lookup to calculate perform
    * @param childRecords Child records being modified
@@ -1275,7 +1279,8 @@ global with sharing class RollupService {
 
     // Process each context (parent child relationship) and its associated rollups
     Map<Id, SObject> masterRecords = new Map<Id, SObject>();
-    for (LREngine.Context ctx : createLREngineContexts(runnowLookups)) {
+    List<LREngine.Context> contexts = createLREngineContexts(runnowLookups);
+    for (LREngine.Context ctx : contexts) {
       // Produce a set of master Id's applicable to this context (parent only)
       Set<Id> ctxMasterIds = new Set<Id>();
       for (Id masterId : masterRecordIds)
@@ -1300,8 +1305,12 @@ global with sharing class RollupService {
       }
     }
 
+    List<SObject> masterRecordsToUpdate = getOnlyRecordsNeedingDml(
+      contexts,
+      masterRecords
+    );
     // Return distinct set of master records will all rollups from all contexts present
-    return masterRecords.values();
+    return masterRecordsToUpdate;
   }
 
   /**
@@ -1580,7 +1589,8 @@ global with sharing class RollupService {
     if (!npspInstalled()) {
       return;
     }
-    Callable npspApi = (System.Callable) Type.forName('npsp', 'Callable_API').newInstance();
+    Callable npspApi = (System.Callable) Type.forName('npsp', 'Callable_API')
+      .newInstance();
     npspApi.call('TDTM.DisableAllTriggers', new Map<String, Object>());
   }
 
@@ -1595,6 +1605,118 @@ global with sharing class RollupService {
     return withSharing
       ? new UpdateWithSharing(masterRecords).updateRecords(allOrNothing)
       : new UpdateWithoutSharing(masterRecords).updateRecords(allOrNothing);
+  }
+
+  /**
+   * Take a set of contexts and proposed changes
+   * Filter down the records to only those that differ from the database
+   */
+  private static List<SObject> getOnlyRecordsNeedingDml(
+    List<LREngine.Context> contexts,
+    Map<Id, SObject> records
+  ) {
+    Map<Schema.SObjectType, Set<Schema.DescribeFieldResult>> parentTypeListOfFields = new Map<Schema.SObjectType, Set<Schema.DescribeFieldResult>>();
+    // Collect parent objects and fields to query them from database
+    Map<Schema.SObjectType, List<SObject>> masterRecordsByType = new Map<Schema.SObjectType, List<SObject>>();
+    for (LREngine.Context ctx : contexts) {
+      // stage object to be filled later
+      masterRecordsByType.put(ctx.master, new List<SObject>());
+      // build up list of parent objects and their fields
+      if (!parentTypeListOfFields.containsKey(ctx.master)) {
+        parentTypeListOfFields.put(
+          ctx.master,
+          new Set<Schema.DescribeFieldResult>()
+        );
+      }
+      for (LREngine.RollupSummaryField f : ctx.fieldsToRoll) {
+        parentTypeListOfFields.get(ctx.master).add(f.master);
+      }
+    }
+    for (SObject obj : records.values()) {
+      Schema.SObjectType t = obj.getSObjectType();
+      masterRecordsByType.get(t).add(obj);
+    }
+
+    // take all parent records of a given type, pull their current state from the database and store it in a map
+    Map<Schema.SObjectType, Map<Id, SObject>> parentsByType = new Map<Schema.SObjectType, Map<Id, SObject>>();
+    for (Schema.SObjectType type : parentTypeListOfFields.keySet()) {
+      parentsByType.put(
+        type,
+        getParentRecords(
+          type,
+          parentTypeListOfFields.get(type),
+          masterRecordsByType.get(type)
+        )
+      );
+    }
+
+    // for each object type, compare the database values and the proposed values
+    // if all values are equal, discard that proposed DML as unecessary
+    List<SObject> masterRecordsToUpdate = new List<SObject>();
+    for (Schema.SObjectType t : masterRecordsByType.keySet()) {
+      masterRecordsToUpdate.addAll(
+        filterParentRecords(masterRecordsByType.get(t), parentsByType.get(t))
+      );
+    }
+    // return a list of all needed changes, might be empty
+    return masterRecordsToUpdate;
+  }
+
+  /**
+   * Retrieve a set of fields for a given SObject whose IDs are present in parents
+   */
+  private static Map<Id, SObject> getParentRecords(
+    Schema.SObjectType sobjectType,
+    Set<Schema.DescribeFieldResult> fields,
+    List<SObject> parents
+  ) {
+    // build a SOQL query and retrieve the parent records
+    // return the parent records
+    fflib_QueryFactory queryFactory = new fflib_QueryFactory(sobjectType)
+      .selectField('Id');
+    for (Schema.DescribeFieldResult f : fields) {
+      queryFactory.selectField(f.getName());
+    }
+    queryFactory.setCondition('Id IN :parents');
+    // Opting not to LOCK the parent records for this action
+    // don't lock them normally in these scenarios and concerned about
+    // what adding a lock would do
+    // at some future point we can add a setting to enable locking here if needed
+    String query = queryFactory.toSOQL();
+    return new Map<Id, SObject>(Database.query(query));
+  }
+
+  /**
+   * compare two sets of SObjects, return records that are not identical
+   * Favoring expectedParents for non-mutual items
+   */
+  private static List<SObject> filterParentRecords(
+    List<SObject> expectedParents,
+    Map<Id, SObject> currentParents
+  ) {
+    List<SObject> parentsNeedingUpdate = new List<SObject>();
+
+    for (SObject expP : expectedParents) {
+      if (!currentParents.containsKey(expP.Id)) {
+        // don't know why this parent wasn't pulled from the database, but assume it needs to be committed
+        parentsNeedingUpdate.add(expP);
+        continue;
+      }
+      // get all fields on the proposed change record
+      Map<String, Object> fieldsMap = expP.getPopulatedFieldsAsMap();
+      // pull the current database snapshot
+      SObject curP = currentParents.get(expP.Id);
+      // for each field on the proposed changes, see if that matches the DB value
+      for (String key : fieldsMap.keySet()) {
+        // if any of the values don't match between objects
+        // enqueue for DML
+        if (expP.get(key) != curP.get(key)) {
+          parentsNeedingUpdate.add(expP);
+          break;
+        }
+      }
+    }
+    return parentsNeedingUpdate;
   }
 
   private virtual class Updater {

--- a/dlrs/main/classes/RollupServiceTest.cls
+++ b/dlrs/main/classes/RollupServiceTest.cls
@@ -1034,14 +1034,16 @@ private with sharing class RollupServiceTest {
     // One query on Rollup object
     // One query on Opportunity for rollup a
     // One query on Opportunity for rollup b
-    System.assertEquals(6, Limits.getQueries());
+    // One query on Parent for values to confirm DML needed
+    System.assertEquals(7, Limits.getQueries());
 
     // One row for ApexTrigger (in the TestContext.isSupported method)
     // One row for ApexTrigger
     // Two rows for Rollup object
     // Two rows for Opportunity for rollup a
     // One rows for Opportunity for rollup b (since its a COUNT and only uses 1 row since Summer'18)
-    System.assertEquals(7, Limits.getQueryRows());
+    // One for Parent
+    System.assertEquals(8, Limits.getQueryRows());
 
     // Assert rollup
     Id accountId = account.Id;
@@ -1062,12 +1064,14 @@ private with sharing class RollupServiceTest {
     // + One query for the Account query above
     // + One query on Rollup object
     // + One query on Opportunity for rollup a
-    System.assertEquals(9, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(11, Limits.getQueries());
 
     // + One query for the Account query above
     // + Two rows for Rollup object
     // + Two rows for Opportunity for rollup a
-    System.assertEquals(12, Limits.getQueryRows());
+    // + One for Parent
+    System.assertEquals(14, Limits.getQueryRows());
 
     // Assert rollup
     accountResult = Database.query(
@@ -1154,13 +1158,15 @@ private with sharing class RollupServiceTest {
     // One query on ApexTrigger (validation when inserting rollups)
     // One query on Rollup object
     // One query on Opportunity for both rollups
-    System.assertEquals(4, Limits.getQueries());
+    // One query on Parent for values to confirm DML needed
+    System.assertEquals(5, Limits.getQueries());
 
     // One row for ApexTrigger (in the TestContext.isSupported method)
     // One row for ApexTrigger
     // Two rows for Rollup object
     // Four rows for Opportunity for rollup a and b
-    System.assertEquals(8, Limits.getQueryRows());
+    // One for Parent
+    System.assertEquals(9, Limits.getQueryRows());
 
     // Assert rollup
     Id accountId = account.Id;
@@ -1181,12 +1187,14 @@ private with sharing class RollupServiceTest {
     // + One query for the Account query above
     // + One query on Rollup object
     // + One query on Opportunity for rollup a
-    System.assertEquals(7, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(9, Limits.getQueries());
 
     // + One query for the Account query above
     // + Two rows for Rollup object
     // + Four rows for Opportunity for rollup a and
-    System.assertEquals(15, Limits.getQueryRows());
+    // + One for Parent
+    System.assertEquals(17, Limits.getQueryRows());
 
     // Assert rollup
     accountResult = Database.query(
@@ -1828,11 +1836,13 @@ private with sharing class RollupServiceTest {
     // Assert limits
     // + One query on Rollup object
     // + One query on Opportunity for rollup
-    System.assertEquals(beforeQueries + 2, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 3, Limits.getQueries());
 
     // + One row for Rollup object
     // + Four rows for Opportunity on Parent 1
-    System.assertEquals(beforeRows + 5, Limits.getQueryRows());
+    // + One for Parent
+    System.assertEquals(beforeRows + 6, Limits.getQueryRows());
 
     // + Twelve rows for Oppportunities (from the update statement itself)
     // + One row for Parent Account 1 (from lookup processing)
@@ -1985,11 +1995,13 @@ private with sharing class RollupServiceTest {
     // Assert limits
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup
-    System.assertEquals(beforeQueries + 2, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 3, Limits.getQueries());
 
     // + Two rows for Rollup object
     // + Two rows for LookupChild__c for rollup B (One on Parent B and One on Parent C)
-    System.assertEquals(beforeRows + 4, Limits.getQueryRows());
+    // + Two for Parents
+    System.assertEquals(beforeRows + 6, Limits.getQueryRows());
 
     // + Two rows for LookupChild__c (from the update statement itself)
     // + Two rows for LookupParent__c (One for B and One for C)
@@ -2429,11 +2441,13 @@ private with sharing class RollupServiceTest {
     // Assert limits
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup
-    System.assertEquals(beforeQueries + 2, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 3, Limits.getQueries());
 
     // + One row for Rollup object
     // + Nine rows for LookupChild__c for rollup
-    System.assertEquals(beforeRows + 10, Limits.getQueryRows());
+    // + Three for Parents
+    System.assertEquals(beforeRows + 13, Limits.getQueryRows());
 
     // + Three rows for LookupChild__c (from the update statement itself)
     // + Three rows for LookupParent__c for the rollup

--- a/dlrs/main/classes/RollupServiceTest3.cls
+++ b/dlrs/main/classes/RollupServiceTest3.cls
@@ -924,10 +924,12 @@ private with sharing class RollupServiceTest3 {
     // Assert no further limits have been used since the field to aggregate on the detail has not changed
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup
-    System.assertEquals(beforeQueries + 2, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 3, Limits.getQueries());
     // + One row for Rollup object
     // + Nine rows for LookupChild__c for rollup
-    System.assertEquals(beforeQueryRows + 10, Limits.getQueryRows());
+    // + Three for Parents
+    System.assertEquals(beforeQueryRows + 13, Limits.getQueryRows());
     // + Three rows for LookupParent__c for rollup target
     System.assertEquals(beforeDMLRows + 3, Limits.getDMLRows());
 
@@ -1192,10 +1194,12 @@ private with sharing class RollupServiceTest3 {
     // Assert no further limits have been used since the field to aggregate on the detail has not changed
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup
-    System.assertEquals(beforeQueries + 2, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 3, Limits.getQueries());
     // + One row for Rollup object
     // + Six rows for LookupChild__c for rollup for Parent A & Parent B
-    System.assertEquals(beforeQueryRows + 7, Limits.getQueryRows());
+    // + Two for Parents
+    System.assertEquals(beforeQueryRows + 9, Limits.getQueryRows());
     // + Two rows for LookupParent__c for rollup target for Parent A & Parent B
     System.assertEquals(beforeDMLRows + 2, Limits.getDMLRows());
 
@@ -1357,10 +1361,12 @@ private with sharing class RollupServiceTest3 {
     // Assert no further limits have been used since the field to aggregate on the detail has not changed
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup
-    System.assertEquals(beforeQueries + 2, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 3, Limits.getQueries());
     // + One row for Rollup object
     // + Six rows for LookupChild__c for rollup for Parent A & Parent B
-    System.assertEquals(beforeQueryRows + 7, Limits.getQueryRows());
+    // + Two for Parents
+    System.assertEquals(beforeQueryRows + 9, Limits.getQueryRows());
     // + Two rows for LookupParent__c for rollup target for Parent A & Parent B
     System.assertEquals(beforeDMLRows + 2, Limits.getDMLRows());
 
@@ -1520,10 +1526,12 @@ private with sharing class RollupServiceTest3 {
     // Assert no further limits have been used since the field to aggregate on the detail has not changed
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup
-    System.assertEquals(beforeQueries + 2, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 3, Limits.getQueries());
     // + One row for Rollup object
     // + Three rows for LookupChild__c
-    System.assertEquals(beforeQueryRows + 4, Limits.getQueryRows());
+    // + Three for Parents
+    System.assertEquals(beforeQueryRows + 7, Limits.getQueryRows());
     // + Three rows for LookupParent__c
     System.assertEquals(beforeDMLRows + 3, Limits.getDMLRows());
 
@@ -1725,10 +1733,12 @@ private with sharing class RollupServiceTest3 {
     // Assert no further limits have been used since the field to aggregate on the detail has not changed
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup
-    System.assertEquals(beforeQueries + 2, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 3, Limits.getQueries());
     // + One row for Rollup object
     // + Six rows for LookupChild__c
-    System.assertEquals(beforeQueryRows + 7, Limits.getQueryRows());
+    // + Three for Parents
+    System.assertEquals(beforeQueryRows + 10, Limits.getQueryRows());
     // + Three rows for LookupParent__c
     System.assertEquals(beforeDMLRows + 3, Limits.getDMLRows());
 

--- a/dlrs/main/classes/RollupServiceTest4.cls
+++ b/dlrs/main/classes/RollupServiceTest4.cls
@@ -285,11 +285,13 @@ private class RollupServiceTest4 {
     // Assert limits
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup
-    System.assertEquals(beforeQueries + 2, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 3, Limits.getQueries());
 
     // + Two rows for Rollup object
     // + Nine rows for LookupChild__c
-    System.assertEquals(beforeRows + 11, Limits.getQueryRows());
+    // + Three for Parents
+    System.assertEquals(beforeRows + 14, Limits.getQueryRows());
 
     // + Nine rows for LookupChild__c (from the update statement itself)
     // + Three rows for LookupParent__c (from rollup processing)
@@ -441,12 +443,14 @@ private class RollupServiceTest4 {
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup A
     // + One query on LookupChild__c for rollup B
-    System.assertEquals(beforeQueries + 3, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 4, Limits.getQueries());
 
     // + Two rows for Rollup object
     // + Nine rows for LookupChild__c for rollup A
     // + Nine rows for LookupChild__c for rollup B
-    System.assertEquals(beforeRows + 20, Limits.getQueryRows());
+    // + Three for Parents
+    System.assertEquals(beforeRows + 23, Limits.getQueryRows());
 
     // + Nine rows for LookupChild__c (from the update statement itself)
     // + Three rows for LookupParent__c for rollup A & B (DLRS combined updates to identical master ids)
@@ -597,11 +601,13 @@ private class RollupServiceTest4 {
     // Assert limits
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup
-    System.assertEquals(beforeQueries + 2, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 3, Limits.getQueries());
 
     // + Two rows for Rollup object
     // + Nine rows for LookupChild__c
-    System.assertEquals(beforeRows + 11, Limits.getQueryRows());
+    // + Three for Parents
+    System.assertEquals(beforeRows + 14, Limits.getQueryRows());
 
     // + Nine rows for LookupChild__c (from the update statement itself)
     // + Three rows for LookupParent__c (from rollup processing)
@@ -753,12 +759,14 @@ private class RollupServiceTest4 {
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup A
     // + One query on LookupChild__c for rollup B
-    System.assertEquals(beforeQueries + 3, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 4, Limits.getQueries());
 
     // + Two rows for Rollup object
     // + Nine rows for LookupChild__c for rollup A
     // + Nine rows for LookupChild__c for rollup B
-    System.assertEquals(beforeRows + 20, Limits.getQueryRows());
+    // + Three for Parents
+    System.assertEquals(beforeRows + 23, Limits.getQueryRows());
 
     // + Nine rows for LookupChild__c (from the update statement itself)
     // + Three rows for LookupParent__c for rollup A & B (DLRS combined updates to identical master ids)
@@ -914,11 +922,13 @@ private class RollupServiceTest4 {
     // Assert limits
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup
-    System.assertEquals(beforeQueries + 2, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 3, Limits.getQueries());
 
     // + Two rows for Rollup object
     // + Nine rows for LookupChild__c
-    System.assertEquals(beforeRows + 11, Limits.getQueryRows());
+    // + Three for Parents
+    System.assertEquals(beforeRows + 14, Limits.getQueryRows());
 
     // + Nine rows for LookupChild__c (from the update statement itself)
     // + Three rows for LookupParent__c (from rollup processing)
@@ -1076,12 +1086,14 @@ private class RollupServiceTest4 {
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup A
     // + One query on LookupChild__c for rollup B
-    System.assertEquals(beforeQueries + 3, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 4, Limits.getQueries());
 
     // + Two rows for Rollup object
     // + Nine rows for LookupChild__c for rollup A
     // + Nine rows for LookupChild__c for rollup B
-    System.assertEquals(beforeRows + 20, Limits.getQueryRows());
+    // + Three for Parents
+    System.assertEquals(beforeRows + 23, Limits.getQueryRows());
 
     // + Nine rows for LookupChild__c (from the update statement itself)
     // + Three rows for LookupParent__c for rollup A & B (DLRS combined updates to identical master ids)
@@ -1242,12 +1254,14 @@ private class RollupServiceTest4 {
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup A
     // + One query on LookupChild__c for rollup B
-    System.assertEquals(beforeQueries + 3, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 4, Limits.getQueries());
 
     // + Two rows for Rollup object
     // + Nine rows for LookupChild__c for rollup A
     // + Nine rows for LookupChild__c for rollup B
-    System.assertEquals(beforeRows + 20, Limits.getQueryRows());
+    // + Three for Parents
+    System.assertEquals(beforeRows + 23, Limits.getQueryRows());
 
     // + Nine rows for LookupChild__c (from the update statement itself)
     // + Three rows for LookupParent__c for rollup A & B (DLRS combined updates to identical master ids)
@@ -1408,11 +1422,13 @@ private class RollupServiceTest4 {
     // Assert limits
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup A & B (single query because orderby matches even though one is not specified)
-    System.assertEquals(beforeQueries + 2, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 3, Limits.getQueries());
 
     // + Two rows for Rollup object
     // + Nine rows for LookupChild__c for rollup A
-    System.assertEquals(beforeRows + 11, Limits.getQueryRows());
+    // + Three for Parents
+    System.assertEquals(beforeRows + 14, Limits.getQueryRows());
 
     // + Nine rows for LookupChild__c (from the insert statement itself)
     // + Three rows for LookupParent__c for rollup A & B (DLRS combined updates to identical master ids)
@@ -1603,11 +1619,13 @@ private class RollupServiceTest4 {
     // Assert limits
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup A, B & C
-    System.assertEquals(beforeQueries + 2, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 3, Limits.getQueries());
 
     // + Three rows for Rollup object
     // + Nine rows for LookupChild__c for rollup A, B & C
-    System.assertEquals(beforeRows + 12, Limits.getQueryRows());
+    // + Three for Parents
+    System.assertEquals(beforeRows + 15, Limits.getQueryRows());
 
     // + Nine rows for LookupChild__c (from the insert statement itself)
     // + Three rows for LookupParent__c for rollup A & B & C (DLRS combined updates to identical master ids)
@@ -1807,11 +1825,13 @@ private class RollupServiceTest4 {
     // Assert limits
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup A, B & C
-    System.assertEquals(beforeQueries + 2, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 3, Limits.getQueries());
 
     // + Three rows for Rollup object
     // + Nine rows for LookupChild__c for rollup A, B & C
-    System.assertEquals(beforeRows + 12, Limits.getQueryRows());
+    // + Three for Parents
+    System.assertEquals(beforeRows + 15, Limits.getQueryRows());
 
     // + Nine rows for LookupChild__c (from the insert statement itself)
     // + Three rows for LookupParent__c for rollup A & B & C (DLRS combined updates to identical master ids)
@@ -2050,11 +2070,13 @@ private class RollupServiceTest4 {
     // Assert limits
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup A, B, C, D & E
-    System.assertEquals(beforeQueries + 2, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 3, Limits.getQueries());
 
     // + Five rows for Rollup object
     // + Nine rows for LookupChild__c for rollup A, B, C, D & E
-    System.assertEquals(beforeRows + 14, Limits.getQueryRows());
+    // + Three for Parents
+    System.assertEquals(beforeRows + 17, Limits.getQueryRows());
 
     // + Nine rows for LookupChild__c (from the insert statement itself)
     // + Three rows for LookupParent__c for rollup A & B & C & D & E (DLRS combined updates to identical master ids)
@@ -2190,12 +2212,14 @@ private class RollupServiceTest4 {
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup A
     // + One query on LookupChild__c for rollup B
-    System.assertEquals(beforeQueries + 3, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 4, Limits.getQueries());
 
     // + Two rows for Rollup object
     // + Nine rows for LookupChild__c for rollup A
     // + Nine rows for LookupChild__c for rollup B
-    System.assertEquals(beforeRows + 20, Limits.getQueryRows());
+    // + Three for Parents
+    System.assertEquals(beforeRows + 23, Limits.getQueryRows());
 
     // + Nine rows for LookupChild__c (from the update statement itself)
     // + Three rows for LookupParent__c for rollup A & B (DLRS combined updates to identical master ids)
@@ -2350,11 +2374,13 @@ private class RollupServiceTest4 {
     // Assert limits
     // + One query on Rollup object
     // + One query on LookupChild__c for rollup
-    System.assertEquals(beforeQueries + 2, Limits.getQueries());
+    // + One query on Parent for values to confirm DML needed
+    System.assertEquals(beforeQueries + 3, Limits.getQueries());
 
     // + Two rows for Rollup object
     // + Nine rows for LookupChild__c
-    System.assertEquals(beforeRows + 11, Limits.getQueryRows());
+    // + Three for Parents
+    System.assertEquals(beforeRows + 14, Limits.getQueryRows());
 
     // + Nine rows for LookupChild__c (from the update statement itself)
     // + Three rows for LookupParent__c (from rollup processing)

--- a/dlrs/main/classes/RollupServiceTest6.cls
+++ b/dlrs/main/classes/RollupServiceTest6.cls
@@ -581,4 +581,102 @@ private class RollupServiceTest6 {
       .Description
     );
   }
+
+  @IsTest
+  static void testRollupPreventUnecessaryParentDmlRealtime() {
+    // Test supported?
+    if (!TestContext.isSupported())
+      return;
+
+    LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
+    rollupSummaryA.Name = 'Test Rollup';
+    rollupSummaryA.ParentObject__c = 'Account';
+    rollupSummaryA.ChildObject__c = 'Account';
+    rollupSummaryA.RelationShipField__c = 'ParentId';
+    rollupSummaryA.FieldToAggregate__c = 'NumberOfEmployees';
+    rollupSummaryA.AggregateOperation__c = RollupSummaries.AggregateOperation.Sum.name();
+    rollupSummaryA.AggregateResultField__c = 'NumberOfEmployees';
+    rollupSummaryA.Active__c = true;
+    rollupSummaryA.CalculationMode__c = 'Realtime';
+    insert rollupSummaryA;
+
+    // Setup parent test records
+    Account accountParent = new Account();
+    accountParent.Name = 'Test Account Parent';
+    accountParent.NumberOfEmployees = 1;
+    insert accountParent;
+
+    Test.startTest();
+    Account accountChild = new Account();
+    accountChild.Name = 'Test Account Child';
+    accountChild.NumberOfEmployees = 1;
+    accountChild.ParentId = accountParent.Id;
+    insert accountChild;
+    // Account insert statement above, no additional DML performed
+    Assert.areEqual(1, Limits.getDmlRows());
+    // No additional rows or unexpected DML
+    Assert.areEqual(1, Limits.getDmlStatements());
+    Test.stopTest();
+
+    // Assert
+    System.assertEquals(
+      1,
+      [SELECT NumberOfEmployees FROM Account WHERE id = :accountParent.Id][0]
+      .NumberOfEmployees
+    );
+  }
+
+  @IsTest
+  static void testRollupPreventUnecessaryParentDmlScheduled() {
+    LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
+    rollupSummaryA.Name = 'Test Rollup';
+    rollupSummaryA.ParentObject__c = 'Account';
+    rollupSummaryA.ChildObject__c = 'Account';
+    rollupSummaryA.RelationShipField__c = 'ParentId';
+    rollupSummaryA.FieldToAggregate__c = 'NumberOfEmployees';
+    rollupSummaryA.AggregateOperation__c = RollupSummaries.AggregateOperation.Sum.name();
+    rollupSummaryA.AggregateResultField__c = 'NumberOfEmployees';
+    rollupSummaryA.Active__c = true;
+    rollupSummaryA.CalculationMode__c = 'Scheduled';
+    insert rollupSummaryA;
+
+    // Setup parent test records
+    Account accountParent = new Account();
+    accountParent.Name = 'Test Opportunity';
+    accountParent.NumberOfEmployees = 1;
+    insert accountParent;
+
+    accountParent = [
+      SELECT Id, LastModifiedDate
+      FROM Account
+      WHERE Id = :accountParent.Id
+    ];
+
+    Test.startTest();
+    Account accountChild = new Account();
+    accountChild.Name = 'Test Opportunity';
+    accountChild.NumberOfEmployees = 1;
+    accountChild.ParentId = accountParent.Id;
+    insert accountChild;
+
+    RollupService.runJobToProcessScheduledItems();
+    Test.stopTest();
+
+    Account accountParentAfterChild = [
+      SELECT Id, LastModifiedDate
+      FROM Account
+      WHERE Id = :accountParent.Id
+    ];
+    Assert.areEqual(
+      accountParent.LastModifiedDate,
+      accountParentAfterChild.LastModifiedDate
+    );
+
+    // Assert
+    Assert.areEqual(
+      1,
+      [SELECT NumberOfEmployees FROM Account WHERE id = :accountParent.Id][0]
+      .NumberOfEmployees
+    );
+  }
 }


### PR DESCRIPTION
Added specific tests to validate these features on both realtime and scheduled mode jobs.
Other tests updates reflect behavior differences in limit counts due to this feature.

# Critical Changes

# Changes

# Issues Closed