### PR TITLE
Feature/865 support platform encryption

### DIFF
--- a/dlrs/libs/fflib-common/classes/fflib_QueryFactoryTest.cls
+++ b/dlrs/libs/fflib-common/classes/fflib_QueryFactoryTest.cls
@@ -299,6 +299,7 @@ private class fflib_QueryFactoryTest {
     Contact cont = new Contact();
     cont.FirstName = 'test';
     cont.LastName = 'test';
+    cont.Department = 'test';
     cont.AccountId = acct.Id;
     insert cont;
     Task tsk = new Task();
@@ -310,7 +311,7 @@ private class fflib_QueryFactoryTest {
     fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
     qf.selectField('name')
       .selectField('Id')
-      .setCondition('name like \'%test%\'')
+      .setCondition('department like \'%test%\'')
       .addOrdering(
         'CreatedDate',
         fflib_QueryFactory.SortOrder.DESCENDING,
@@ -338,6 +339,7 @@ private class fflib_QueryFactoryTest {
     Contact cont = new Contact();
     cont.FirstName = 'test';
     cont.LastName = 'test';
+    cont.Department = 'test';
     cont.AccountId = acct.Id;
     insert cont;
     Task tsk = new Task();
@@ -349,7 +351,7 @@ private class fflib_QueryFactoryTest {
     fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
     qf.selectField('name')
       .selectField('Id')
-      .setCondition('name like \'%test%\'')
+      .setCondition('department like \'%test%\'')
       .addOrdering(
         'CreatedDate',
         fflib_QueryFactory.SortOrder.DESCENDING,
@@ -378,6 +380,7 @@ private class fflib_QueryFactoryTest {
     Contact cont = new Contact();
     cont.FirstName = 'test';
     cont.LastName = 'test';
+    cont.Department = 'test';
     cont.AccountId = acct.Id;
     insert cont;
     Task tsk = new Task();
@@ -389,7 +392,7 @@ private class fflib_QueryFactoryTest {
     fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
     qf.selectField('name')
       .selectField('Id')
-      .setCondition('name like \'%test%\'')
+      .setCondition('department like \'%test%\'')
       .addOrdering(
         'CreatedDate',
         fflib_QueryFactory.SortOrder.DESCENDING,
@@ -427,6 +430,7 @@ private class fflib_QueryFactoryTest {
     Contact cont = new Contact();
     cont.FirstName = 'test';
     cont.LastName = 'test';
+    cont.Department = 'test';
     cont.AccountId = acct.Id;
     insert cont;
     Task tsk = new Task();
@@ -438,7 +442,7 @@ private class fflib_QueryFactoryTest {
     fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
     qf.selectField('name')
       .selectField('Id')
-      .setCondition('name like \'%test%\'')
+      .setCondition('department like \'%test%\'')
       .addOrdering(
         'CreatedDate',
         fflib_QueryFactory.SortOrder.DESCENDING,
@@ -516,6 +520,7 @@ private class fflib_QueryFactoryTest {
     Contact cont = new Contact();
     cont.FirstName = 'test';
     cont.LastName = 'test';
+    cont.Department = 'test';
     cont.AccountId = acct.Id;
     insert cont;
     Task tsk = new Task();
@@ -527,7 +532,7 @@ private class fflib_QueryFactoryTest {
     fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
     qf.selectField('name')
       .selectField('Id')
-      .setCondition('name like \'%test%\'')
+      .setCondition('department like \'%test%\'')
       .addOrdering(
         'CreatedDate',
         fflib_QueryFactory.SortOrder.DESCENDING,

--- a/dlrs/libs/fflib-common/classes/fflib_SObjectSelectorTest.cls
+++ b/dlrs/libs/fflib-common/classes/fflib_SObjectSelectorTest.cls
@@ -184,7 +184,7 @@ private with sharing class fflib_SObjectSelectorTest {
     Testfflib_SObjectSelector selector = new Testfflib_SObjectSelector();
     String soql = selector.newQueryFactory().toSOQL();
     Pattern p = Pattern.compile(
-      'SELECT (.*) FROM Account ORDER BY Name DESC NULLS FIRST , AnnualRevenue ASC NULLS FIRST '
+      'SELECT (.*) FROM Account ORDER BY AccountNumber DESC NULLS FIRST , AnnualRevenue ASC NULLS FIRST '
     );
     Matcher m = p.matcher(soql);
     System.assert(
@@ -288,7 +288,7 @@ private with sharing class fflib_SObjectSelectorTest {
 
     //Then
     Pattern soqlPattern = Pattern.compile(
-      'SELECT (.*) FROM Account ORDER BY Name DESC NULLS FIRST , AnnualRevenue ASC NULLS FIRST '
+      'SELECT (.*) FROM Account ORDER BY AccountNumber DESC NULLS FIRST , AnnualRevenue ASC NULLS FIRST '
     );
     Matcher soqlMatcher = soqlPattern.matcher(soql);
     soqlMatcher.matches();
@@ -344,7 +344,7 @@ private with sharing class fflib_SObjectSelectorTest {
     }
 
     public override String getOrderBy() {
-      return 'Name DESC, AnnualRevenue ASC';
+      return 'AccountNumber DESC, AnnualRevenue ASC';
     }
   }
 

--- a/dlrs/libs/fflib-common/classes/fflib_SObjectUnitOfWorkTest.cls
+++ b/dlrs/libs/fflib-common/classes/fflib_SObjectUnitOfWorkTest.cls
@@ -59,8 +59,6 @@ private with sharing class fflib_SObjectUnitOfWorkTest {
     List<Opportunity> opps = [
       SELECT Id, Name, (SELECT Id FROM OpportunityLineItems)
       FROM Opportunity
-      WHERE Name = :testRecordName
-      ORDER BY Name
     ];
 
     // assert that an email was sent
@@ -115,8 +113,6 @@ private with sharing class fflib_SObjectUnitOfWorkTest {
     List<Opportunity> opps = [
       SELECT Id, Name, (SELECT Id FROM OpportunityLineItems)
       FROM Opportunity
-      WHERE Name LIKE 'UoW Test Name %'
-      ORDER BY Name
     ];
 
     // Update some records with UnitOfWork
@@ -167,8 +163,6 @@ private with sharing class fflib_SObjectUnitOfWorkTest {
           ORDER BY PricebookEntry.Product2.Name
         )
       FROM Opportunity
-      WHERE Name LIKE 'UoW Test Name %'
-      ORDER BY Name
     ];
     System.assertEquals(10, opps.size());
     System.assertEquals('UoW Test Name 0 Changed', opps[0].Name);
@@ -221,8 +215,6 @@ private with sharing class fflib_SObjectUnitOfWorkTest {
           ORDER BY PricebookEntry.Product2.Name
         )
       FROM Opportunity
-      WHERE Name LIKE 'UoW Test Name %'
-      ORDER BY Name
     ];
     List<Product2> prods = [
       SELECT Id
@@ -237,12 +229,9 @@ private with sharing class fflib_SObjectUnitOfWorkTest {
 
   private static void assertResults(String prefix) {
     // Standard Assertions on tests data inserted by tests
-    String filter = prefix + ' Test Name %';
     List<Opportunity> opps = [
       SELECT Id, Name, (SELECT Id FROM OpportunityLineItems)
       FROM Opportunity
-      WHERE Name LIKE :filter
-      ORDER BY Name
     ];
     System.assertEquals(10, opps.size());
     System.assertEquals(1, opps[0].OpportunityLineItems.size());

--- a/dlrs/libs/lrengine/classes/TestLREngine.cls
+++ b/dlrs/libs/lrengine/classes/TestLREngine.cls
@@ -1137,7 +1137,7 @@ private class TestLREngine {
 
   static testMethod void testRollupConcatenateOrderByMultipleAscendingNullsFirst() {
     testRollup2(
-      'CloseDate, Type, Amount, Name',
+      'CloseDate, Type, Amount, StageName',
       new LREngine.RollupSummaryField(
         Schema.SObjectType.Account.fields.Description,
         Schema.SObjectType.Opportunity.fields.StageName,
@@ -1145,13 +1145,13 @@ private class TestLREngine {
         ','
       ),
       'blue,red,yellow',
-      'orange,green,purple'
+      'green,orange,purple'
     );
   }
 
   static testMethod void testRollupConcatenateOrderByMultipleAscendingNullsLast() {
     testRollup2(
-      'CloseDate NULLS LAST, Type NULLS LAST, Amount NULLS LAST, Name NULLS LAST',
+      'CloseDate NULLS LAST, Type NULLS LAST, Amount NULLS LAST, StageName NULLS LAST',
       new LREngine.RollupSummaryField(
         Schema.SObjectType.Account.fields.Description,
         Schema.SObjectType.Opportunity.fields.StageName,
@@ -1159,13 +1159,13 @@ private class TestLREngine {
         ','
       ),
       'red,yellow,blue',
-      'orange,green,purple'
+      'green,orange,purple'
     );
   }
 
   static testMethod void testRollupConcatenateOrderByMultipleDescendingNullsFirst() {
     testRollup2(
-      'CloseDate DESC, Type DESC, Amount DESC, Name DESC',
+      'CloseDate DESC, Type DESC, Amount DESC, StageName DESC',
       new LREngine.RollupSummaryField(
         Schema.SObjectType.Account.fields.Description,
         Schema.SObjectType.Opportunity.fields.StageName,
@@ -1173,13 +1173,13 @@ private class TestLREngine {
         ','
       ),
       'blue,yellow,red',
-      'purple,green,orange'
+      'purple,orange,green'
     );
   }
 
   static testMethod void testRollupConcatenateOrderByMultipleDescendingNullsLast() {
     testRollup2(
-      'CloseDate DESC NULLS LAST, Type DESC NULLS LAST, Amount DESC NULLS LAST, Name DESC NULLS LAST',
+      'CloseDate DESC NULLS LAST, Type DESC NULLS LAST, Amount DESC NULLS LAST, StageName DESC NULLS LAST',
       new LREngine.RollupSummaryField(
         Schema.SObjectType.Account.fields.Description,
         Schema.SObjectType.Opportunity.fields.StageName,
@@ -1187,7 +1187,7 @@ private class TestLREngine {
         ','
       ),
       'yellow,red,blue',
-      'purple,green,orange'
+      'purple,orange,green'
     );
   }
 
@@ -1235,7 +1235,7 @@ private class TestLREngine {
 
   static testMethod void testRollupConcatenateDistinctWithMultipleFieldsOrderBy() {
     testRollup(
-      'Amount DESC, CloseDate DESC, Type DESC, Name DESC',
+      'Amount DESC, CloseDate DESC, Type DESC, StageName DESC',
       new LREngine.RollupSummaryField(
         Schema.SObjectType.Account.fields.Description,
         Schema.SObjectType.Opportunity.fields.StageName,

--- a/dlrs/main/classes/RollupServiceTest.cls
+++ b/dlrs/main/classes/RollupServiceTest.cls
@@ -1472,12 +1472,12 @@ private with sharing class RollupServiceTest {
     // Test data for rollup A
     String expectedResultA = 'Prospecting';
     RollupSummaries.AggregateOperation operationA = RollupSummaries.AggregateOperation.First;
-    String orderByClauseA = 'Amount ASC NULLS FIRST, CloseDate ASC NULLS FIRST, Name';
+    String orderByClauseA = 'Amount ASC NULLS FIRST, CloseDate ASC NULLS FIRST, StageName';
 
     // Test data for rollup B
     String expectedResultB = 'Kim,Joe,Charlie,Steve';
     RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Concatenate;
-    String orderByClauseB = 'Amount ASC NULLS FIRST, CloseDate DESC NULLS FIRST, Name';
+    String orderByClauseB = 'Amount ASC NULLS FIRST, CloseDate DESC NULLS FIRST, StageName';
 
     // generate rollups and data
     Id accountId = setupMultiRollupDifferentTypes(


### PR DESCRIPTION
To support orgs with Encrypted Opp.Name fields we can't use them in WHERE clauses or ORDER BY clauses.

# Changes
Enable installing DLRS in orgs with encrypted fields

# Issues Closed
#865 

QA Notes
You have to enable Platform Encryption fields during scratch org creation, create a Perm Set to manage Encryption Keys, create Encryption Keys, enable encryption of all possible standard fields. Push DLRS into the org then then run all Apex tests.

This change does NOT guarantee DLRS will be fully functional in an org with encrypted fields, only ensures it will install and that none of the actions will break. Users can still configure a DLRS rollup in such a way that it incorrectly uses an encrypted field. Will probably want a page in the docs to talk about Shield Encryption and what won't work and what errors might come up.