### PR TITLE
Guard tests that depend on unpackaged triggers

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -48,27 +48,16 @@ tasks:
         - "UNABLE_TO_LOCK_ROW"
       retry_always: True
 
-  uninstall_packaged_incremental:
-    options:
-      ignore:
-        # This trigger is not intended for packaging,
-        # but is spidered in. We can't currently prevent that behavior.
-        ApexTrigger:
-          - UnpackagedRollupServiceTest2Trigger
 flows:
   ci_beta:
     steps:
       1.5:
         task: deploy_test_config
-      1.6:
-        task: deploy_test_triggers
 
   ci_release:
     steps:
       1.5:
         task: deploy_test_config
-      1.6:
-        task: deploy_test_triggers
 
   config_apextest:
     steps:
@@ -112,8 +101,6 @@ flows:
         task: dx_convert_from
         options:
           extra: "--sourcepath ./dlrs/libs/fflib-apexmocks,./dlrs/libs/fflib-common,./dlrs/libs/lrengine,./dlrs/libs/metadataservice,./dlrs/main"
-      4.1:
-        task: deploy_test_triggers
 
   config_dev:
     steps:

--- a/dlrs/main/classes/RollupCalculateControllerTest.cls
+++ b/dlrs/main/classes/RollupCalculateControllerTest.cls
@@ -27,14 +27,12 @@
 @IsTest
 private class RollupCalculateControllerTest {
   static Schema.SObjectField ACCOUNT_SLA_EXPIRATION_DATE;
-  static Schema.SObjectField ACCOUNT_NUMBER_OF_LOCATIONS;
   static {
     // Dynamically resolve these fields, if they are not present when the test runs, the test will return as passed to avoid failures in subscriber org when packaged
     fflib_SObjectDescribe describe = fflib_SObjectDescribe.getDescribe(
       Account.SObjectType
     );
     ACCOUNT_SLA_EXPIRATION_DATE = describe.getField('SLAExpirationDate__c');
-    ACCOUNT_NUMBER_OF_LOCATIONS = describe.getField('NumberOfLocations__c');
   }
 
   @IsTest
@@ -87,7 +85,7 @@ private class RollupCalculateControllerTest {
     // Assert rollups are null
     Id accountId = account1.Id;
     Account accountResult = Database.query(
-      'select AnnualRevenue, NumberOfLocations__c from Account where Id = :accountId'
+      'select AnnualRevenue from Account where Id = :accountId'
     );
     System.assertEquals(null, accountResult.AnnualRevenue);
 
@@ -99,7 +97,7 @@ private class RollupCalculateControllerTest {
 
     // Assert rollups are calculated
     accountResult = Database.query(
-      'select AnnualRevenue, NumberOfLocations__c from Account where Id = :accountId'
+      'select AnnualRevenue from Account where Id = :accountId'
     );
     System.assertEquals(expectedResultA, accountResult.AnnualRevenue);
 
@@ -121,14 +119,14 @@ private class RollupCalculateControllerTest {
     System.assertEquals(
       /* Expected following additional query rows */
       /* Lookup row **/ +1 +
-      /* Rollup query rows (children) **/ rollups.size() +
-      /* Master query rows (parents) */ accounts.size(),
+        /* Rollup query rows (children) **/ rollups.size() +
+        /* Master query rows (parents) */ accounts.size(),
       Limits.getQueryRows() - queryRows
     );
 
     // Assert rollups are still ok
     accountResult = Database.query(
-      'select AnnualRevenue, NumberOfLocations__c from Account where Id = :accountId'
+      'select AnnualRevenue from Account where Id = :accountId'
     );
     System.assertEquals(expectedResultA, accountResult.AnnualRevenue);
 
@@ -155,14 +153,14 @@ private class RollupCalculateControllerTest {
     System.assertEquals(
       /* Expected following additional query rows */
       /* Lookup row **/ +1 +
-      /* Rollup query rows (children) **/ rollups.size() +
-      /* Master query rows (parents) */ accounts.size(),
+        /* Rollup query rows (children) **/ rollups.size() +
+        /* Master query rows (parents) */ accounts.size(),
       Limits.getQueryRows() - queryRows
     );
 
     // Assert rollups are still ok
     accountResult = Database.query(
-      'select AnnualRevenue, NumberOfLocations__c from Account where Id = :accountId'
+      'select AnnualRevenue from Account where Id = :accountId'
     );
     System.assertEquals(expectedResultA, accountResult.AnnualRevenue);
   }

--- a/dlrs/main/classes/RollupServiceTest4.cls
+++ b/dlrs/main/classes/RollupServiceTest4.cls
@@ -43,6 +43,11 @@ private class RollupServiceTest4 {
     Decimal expectedValue2,
     String sharingMode
   ) {
+    // Test supported?
+    if (!TestContext.isSupported()) {
+      return;
+    }
+
     // Create test user A
     User testUserA = null;
     System.runAs(new User(Id = UserInfo.getUserId())) {

--- a/dlrs/main/classes/RollupServiceTest6.cls
+++ b/dlrs/main/classes/RollupServiceTest6.cls
@@ -676,6 +676,11 @@ private class RollupServiceTest6 {
 
   @IsTest
   static void testRollupPreventUnecessaryParentDmlScheduled() {
+    // Test supported?
+    if (!TestContext.isSupported()) {
+      return;
+    }
+
     LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
     rollupSummaryA.Name = 'Test Rollup';
     rollupSummaryA.ParentObject__c = 'Account';
@@ -730,6 +735,10 @@ private class RollupServiceTest6 {
 
   @IsTest
   static void testRollupPreventUnecessaryParentDmlScheduledRespectDisable() {
+    // Test supported?
+    if (!TestContext.isSupported()) {
+      return;
+    }
     DeclarativeLookupRollupSummaries__c settings = new DeclarativeLookupRollupSummaries__c(
       DisableParentDMLCheck__c = true
     );


### PR DESCRIPTION
# Critical Changes
Resolve test guards that should have been blocked but were seeing the packaged triggers and running.

# Changes
Cleaned up one file and added standard guards to two others that were missing them.

# Issues Closed
#1364 