### PR TITLE
enable RollupController get API version from org

### DIFF
--- a/dlrs/main/classes/RollupController.cls
+++ b/dlrs/main/classes/RollupController.cls
@@ -28,7 +28,8 @@
  * Handles the Manage Trigger and Calculate Custom Buttons
  **/
 public with sharing class RollupController {
-  public static String DEF_API_VERSION = '58.0';
+  @TestVisible
+  private static String FALLBACK_COMPONENT_API_VERSION = '58.0';
 
   public String ZipData { get; set; }
 
@@ -59,9 +60,11 @@ public with sharing class RollupController {
   public ApexClass RollupParentTriggerTest { get; private set; }
 
   public Integer deployCount;
-  public String apiVersion;
 
   public Boolean MetadataConnectionError { get; set; }
+
+  @TestVisible
+  private String componentApiVersion;
 
   public RollupController(ApexPages.StandardController standardController) {
     // Query Lookup Rollup Summary record
@@ -101,7 +104,7 @@ public with sharing class RollupController {
       return '<?xml version="1.0" encoding="UTF-8"?>' +
         '<Package xmlns="http://soap.sforce.com/2006/04/metadata">' +
         '<version>' +
-        apiVersion +
+        componentApiVersion +
         '</version>' +
         '</Package>';
     else
@@ -135,7 +138,7 @@ public with sharing class RollupController {
             '</types>')
           : '') +
         '<version>' +
-        apiVersion +
+        componentApiVersion +
         '</version>' +
         '</Package>';
   }
@@ -170,7 +173,7 @@ public with sharing class RollupController {
           '</types>')
         : '') +
       '<version>' +
-      apiVersion +
+      componentApiVersion +
       '</version>' +
       '</Package>';
   }
@@ -183,7 +186,7 @@ public with sharing class RollupController {
     return '<?xml version="1.0" encoding="UTF-8"?>' +
       '<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">' +
       '<apiVersion>' +
-      apiVersion +
+      componentApiVersion +
       '</apiVersion>' +
       '<status>Active</status>' +
       '</ApexClass>';
@@ -228,7 +231,7 @@ public with sharing class RollupController {
     return '<?xml version="1.0" encoding="UTF-8"?>' +
       '<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">' +
       '<apiVersion>' +
-      apiVersion +
+      componentApiVersion +
       '</apiVersion>' +
       '<status>Active</status>' +
       '</ApexTrigger>';
@@ -269,7 +272,7 @@ public with sharing class RollupController {
     return '<?xml version="1.0" encoding="UTF-8"?>' +
       '<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">' +
       '<apiVersion>' +
-      apiVersion +
+      componentApiVersion +
       '</apiVersion>' +
       '<status>Active</status>' +
       '</ApexClass>';
@@ -316,7 +319,7 @@ public with sharing class RollupController {
     return '<?xml version="1.0" encoding="UTF-8"?>' +
       '<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">' +
       '<apiVersion>' +
-      apiVersion +
+      componentApiVersion +
       '</apiVersion>' +
       '<status>Active</status>' +
       '</ApexTrigger>';
@@ -493,7 +496,7 @@ public with sharing class RollupController {
       );
       return;
     }
-    apiVersion = getNewestApiVersion();
+    componentApiVersion = getNewestApiVersion();
 
     // Already deployed?
     Set<String> triggerNames = new Set<String>{ RollupTriggerName };
@@ -602,11 +605,11 @@ public with sharing class RollupController {
       Http http = new Http();
       HTTPResponse res = http.send(req);
       if (res.getStatusCode() != 200) {
-        return DEF_API_VERSION;
+        return FALLBACK_COMPONENT_API_VERSION;
       }
       String body = res.getBody();
       List<Object> data = (List<Object>) JSON.deserializeUntyped(body);
-      Decimal maxVersion = Decimal.valueOf(DEF_API_VERSION);
+      Decimal maxVersion = Decimal.valueOf(FALLBACK_COMPONENT_API_VERSION);
       for (Object obj : data) {
         Map<String, Object> apiV = (Map<String, Object>) obj;
         Decimal newV = Decimal.valueOf((String) apiV.get('version'));
@@ -616,7 +619,8 @@ public with sharing class RollupController {
       }
       return String.valueOf(maxVersion);
     } catch (Exception e) {
-      return DEF_API_VERSION;
+      System.debug(e);
+      return FALLBACK_COMPONENT_API_VERSION;
     }
   }
 

--- a/dlrs/main/classes/RollupController.cls
+++ b/dlrs/main/classes/RollupController.cls
@@ -28,8 +28,7 @@
  * Handles the Manage Trigger and Calculate Custom Buttons
  **/
 public with sharing class RollupController {
-  
-  public static String API_VERSION = '58.0';
+  public static String DEF_API_VERSION = '58.0';
 
   public String ZipData { get; set; }
 
@@ -60,6 +59,7 @@ public with sharing class RollupController {
   public ApexClass RollupParentTriggerTest { get; private set; }
 
   public Integer deployCount;
+  public String apiVersion;
 
   public Boolean MetadataConnectionError { get; set; }
 
@@ -101,7 +101,7 @@ public with sharing class RollupController {
       return '<?xml version="1.0" encoding="UTF-8"?>' +
         '<Package xmlns="http://soap.sforce.com/2006/04/metadata">' +
         '<version>' +
-        API_VERSION +
+        apiVersion +
         '</version>' +
         '</Package>';
     else
@@ -135,7 +135,7 @@ public with sharing class RollupController {
             '</types>')
           : '') +
         '<version>' +
-        API_VERSION +
+        apiVersion +
         '</version>' +
         '</Package>';
   }
@@ -170,7 +170,7 @@ public with sharing class RollupController {
           '</types>')
         : '') +
       '<version>' +
-      API_VERSION +
+      apiVersion +
       '</version>' +
       '</Package>';
   }
@@ -183,7 +183,7 @@ public with sharing class RollupController {
     return '<?xml version="1.0" encoding="UTF-8"?>' +
       '<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">' +
       '<apiVersion>' +
-      API_VERSION +
+      apiVersion +
       '</apiVersion>' +
       '<status>Active</status>' +
       '</ApexClass>';
@@ -228,7 +228,7 @@ public with sharing class RollupController {
     return '<?xml version="1.0" encoding="UTF-8"?>' +
       '<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">' +
       '<apiVersion>' +
-      API_VERSION +
+      apiVersion +
       '</apiVersion>' +
       '<status>Active</status>' +
       '</ApexTrigger>';
@@ -269,7 +269,7 @@ public with sharing class RollupController {
     return '<?xml version="1.0" encoding="UTF-8"?>' +
       '<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">' +
       '<apiVersion>' +
-      API_VERSION +
+      apiVersion +
       '</apiVersion>' +
       '<status>Active</status>' +
       '</ApexClass>';
@@ -316,7 +316,7 @@ public with sharing class RollupController {
     return '<?xml version="1.0" encoding="UTF-8"?>' +
       '<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">' +
       '<apiVersion>' +
-      API_VERSION +
+      apiVersion +
       '</apiVersion>' +
       '<status>Active</status>' +
       '</ApexTrigger>';
@@ -403,12 +403,12 @@ public with sharing class RollupController {
               new ApexPages.Message(
                 ApexPages.Severity.Error,
                 deployMessage.fileName +
-                ' (Line: ' +
-                deployMessage.lineNumber +
-                ': Column:' +
-                deployMessage.columnNumber +
-                ') : ' +
-                deployMessage.problem
+                  ' (Line: ' +
+                  deployMessage.lineNumber +
+                  ': Column:' +
+                  deployMessage.columnNumber +
+                  ') : ' +
+                  deployMessage.problem
               )
             );
       // Test errors?
@@ -421,12 +421,12 @@ public with sharing class RollupController {
             new ApexPages.Message(
               ApexPages.Severity.Error,
               testFailure.name +
-              '.' +
-              testFailure.methodName +
-              ' ' +
-              testFailure.message +
-              ' ' +
-              testFailure.stackTrace
+                '.' +
+                testFailure.methodName +
+                ' ' +
+                testFailure.message +
+                ' ' +
+                testFailure.stackTrace
             )
           );
       // Code coverage warnings?
@@ -438,11 +438,11 @@ public with sharing class RollupController {
             new ApexPages.Message(
               ApexPages.Severity.Warning,
               (codeCoverageWarning.namespace != null
-                ? codeCoverageWarning.namespace + '.'
-                : '') +
-              codeCoverageWarning.name +
-              ':' +
-              codeCoverageWarning.message
+                  ? codeCoverageWarning.namespace + '.'
+                  : '') +
+                codeCoverageWarning.name +
+                ':' +
+                codeCoverageWarning.message
             )
           );
 
@@ -493,6 +493,7 @@ public with sharing class RollupController {
       );
       return;
     }
+    apiVersion = getNewestApiVersion();
 
     // Already deployed?
     Set<String> triggerNames = new Set<String>{ RollupTriggerName };
@@ -566,8 +567,8 @@ public with sharing class RollupController {
           new ApexPages.Message(
             ApexPages.Severity.Info,
             'Apex Trigger <b>' +
-            RollupParentTriggerTestName +
-            '</b> is installed.'
+              RollupParentTriggerTestName +
+              '</b> is installed.'
           )
         );
       }
@@ -584,6 +585,38 @@ public with sharing class RollupController {
           'Click <b>Deploy</b> to install the Apex Trigger and Apex Class for this child object.'
         )
       );
+    }
+  }
+
+  /**
+   * Call salesforce API to get current max supported API version
+   */
+  private String getNewestApiVersion() {
+    HttpRequest req = new HttpRequest();
+    req.setMethod('GET');
+    // submit a Versions request
+    req.setEndpoint(URL.getOrgDomainUrl().toExternalForm() + '/services/data/');
+    // Salesforce REST API Dev Guide says this endpoint doesn't need authentication
+
+    try {
+      Http http = new Http();
+      HTTPResponse res = http.send(req);
+      if (res.getStatusCode() != 200) {
+        return DEF_API_VERSION;
+      }
+      String body = res.getBody();
+      List<Object> data = (List<Object>) JSON.deserializeUntyped(body);
+      Decimal maxVersion = Decimal.valueOf(DEF_API_VERSION);
+      for (Object obj : data) {
+        Map<String, Object> apiV = (Map<String, Object>) obj;
+        Decimal newV = Decimal.valueOf((String) apiV.get('version'));
+        if (newV > maxVersion) {
+          maxVersion = newV;
+        }
+      }
+      return String.valueOf(maxVersion);
+    } catch (Exception e) {
+      return DEF_API_VERSION;
     }
   }
 

--- a/dlrs/main/classes/RollupControllerTest.cls
+++ b/dlrs/main/classes/RollupControllerTest.cls
@@ -32,8 +32,7 @@ private class RollupControllerTest {
       return;
 
     System.runAs(setupTestUser()) {
-      // Metadata API web Service mock implementation for tests
-      Test.setMock(WebServiceMock.class, new WebServiceMockImpl());
+      setupMocks();
 
       // Test data
       LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
@@ -96,7 +95,7 @@ private class RollupControllerTest {
         '<?xml version="1.0" encoding="UTF-8"?>' +
           '<Package xmlns="http://soap.sforce.com/2006/04/metadata">' +
           '<version>' +
-          RollupController.API_VERSION +
+          controller.apiVersion +
           '</version>' +
           '</Package>',
         controller.getPackageXml()
@@ -117,7 +116,7 @@ private class RollupControllerTest {
           '<name>ApexClass</name>' +
           '</types>' +
           '<version>' +
-          RollupController.API_VERSION +
+          controller.apiVersion +
           '</version>' +
           '</Package>',
         controller.getDestructiveChangesXml()
@@ -126,7 +125,7 @@ private class RollupControllerTest {
         '<?xml version="1.0" encoding="UTF-8"?>' +
           '<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">' +
           '<apiVersion>' +
-          RollupController.API_VERSION +
+          controller.apiVersion +
           '</apiVersion>' +
           '<status>Active</status>' +
           '</ApexTrigger>',
@@ -136,7 +135,7 @@ private class RollupControllerTest {
         '<?xml version="1.0" encoding="UTF-8"?>' +
           '<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">' +
           '<apiVersion>' +
-          RollupController.API_VERSION +
+          controller.apiVersion +
           '</apiVersion>' +
           '<status>Active</status>' +
           '</ApexClass>',
@@ -595,10 +594,7 @@ private class RollupControllerTest {
     List<Profile> profiles = [
       SELECT id, Name
       FROM Profile
-      WHERE
-        Name = 'Read Only'
-        OR Name = 'ReadOnly'
-        OR Name = 'Standard User'
+      WHERE Name = 'Read Only' OR Name = 'ReadOnly' OR Name = 'Standard User'
       ORDER BY Name ASC
     ];
     system.assert(

--- a/dlrs/main/classes/RollupControllerTest.cls
+++ b/dlrs/main/classes/RollupControllerTest.cls
@@ -94,52 +94,52 @@ private class RollupControllerTest {
       );
       System.assertEquals(
         '<?xml version="1.0" encoding="UTF-8"?>' +
-        '<Package xmlns="http://soap.sforce.com/2006/04/metadata">' +
-        '<version>' +
-        RollupController.API_VERSION +
-        '</version>' +
-        '</Package>',
+          '<Package xmlns="http://soap.sforce.com/2006/04/metadata">' +
+          '<version>' +
+          RollupController.API_VERSION +
+          '</version>' +
+          '</Package>',
         controller.getPackageXml()
       );
       System.assertEquals(
         '<?xml version="1.0" encoding="UTF-8"?>' +
-        '<Package xmlns="http://soap.sforce.com/2006/04/metadata">' +
-        '<types>' +
-        '<members>' +
-        controller.RollupTriggerName +
-        '</members>' +
-        '<name>ApexTrigger</name>' +
-        '</types>' +
-        '<types>' +
-        '<members>' +
-        controller.RollupTriggerTestName +
-        '</members>' +
-        '<name>ApexClass</name>' +
-        '</types>' +
-        '<version>' +
-        RollupController.API_VERSION +
-        '</version>' +
-        '</Package>',
+          '<Package xmlns="http://soap.sforce.com/2006/04/metadata">' +
+          '<types>' +
+          '<members>' +
+          controller.RollupTriggerName +
+          '</members>' +
+          '<name>ApexTrigger</name>' +
+          '</types>' +
+          '<types>' +
+          '<members>' +
+          controller.RollupTriggerTestName +
+          '</members>' +
+          '<name>ApexClass</name>' +
+          '</types>' +
+          '<version>' +
+          RollupController.API_VERSION +
+          '</version>' +
+          '</Package>',
         controller.getDestructiveChangesXml()
       );
       System.assertEquals(
         '<?xml version="1.0" encoding="UTF-8"?>' +
-        '<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">' +
-        '<apiVersion>' +
-        RollupController.API_VERSION +
-        '</apiVersion>' +
-        '<status>Active</status>' +
-        '</ApexTrigger>',
+          '<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">' +
+          '<apiVersion>' +
+          RollupController.API_VERSION +
+          '</apiVersion>' +
+          '<status>Active</status>' +
+          '</ApexTrigger>',
         controller.getTriggerCodeMetadata()
       );
       System.assertEquals(
         '<?xml version="1.0" encoding="UTF-8"?>' +
-        '<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">' +
-        '<apiVersion>' +
-        RollupController.API_VERSION +
-        '</apiVersion>' +
-        '<status>Active</status>' +
-        '</ApexClass>',
+          '<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">' +
+          '<apiVersion>' +
+          RollupController.API_VERSION +
+          '</apiVersion>' +
+          '<status>Active</status>' +
+          '</ApexClass>',
         controller.getTriggerTestCodeMetadata()
       );
 
@@ -168,8 +168,7 @@ private class RollupControllerTest {
       return;
 
     System.runAs(setupTestUser()) {
-      // Metadata API web Service mock implementation for tests
-      Test.setMock(WebServiceMock.class, new WebServiceMockImpl());
+      setupMocks();
 
       // Test data
       LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
@@ -197,96 +196,96 @@ private class RollupControllerTest {
       System.assertEquals(null, controller.RollupTriggerTest);
       System.assertEquals(
         '/**\n' +
-        ' * Auto Generated and Deployed by the Declarative Lookup Rollup Summaries Tool package (dlrs)\n' +
-        ' **/\n' +
-        'trigger ' +
-        controller.RollupTriggerName +
-        ' on ' +
-        rollupSummary.ChildObject__c +
-        '\n' +
-        '    (before delete, before insert, before update, after delete, after insert, after undelete, after update)\n' +
-        '{\n' +
-        '    ' +
-        Utilities.classPrefix() +
-        'RollupService.triggerHandler(Contact.SObjectType);\n' +
-        '}\n',
+          ' * Auto Generated and Deployed by the Declarative Lookup Rollup Summaries Tool package (dlrs)\n' +
+          ' **/\n' +
+          'trigger ' +
+          controller.RollupTriggerName +
+          ' on ' +
+          rollupSummary.ChildObject__c +
+          '\n' +
+          '    (before delete, before insert, before update, after delete, after insert, after undelete, after update)\n' +
+          '{\n' +
+          '    ' +
+          Utilities.classPrefix() +
+          'RollupService.triggerHandler(Contact.SObjectType);\n' +
+          '}\n',
         controller.getTriggerCode()
       );
       System.assertEquals(
         '/**\n' +
-        ' * Auto Generated and Deployed by the Declarative Lookup Rollup Summaries Tool package (dlrs)\n' +
-        ' **/\n' +
-        '@IsTest\n' +
-        'private class ' +
-        controller.RollupTriggerTestName +
-        '\n' +
-        '{\n' +
-        '    @IsTest\n' +
-        '    private static void testTrigger()\n' +
-        '    {\n' +
-        '        // Force the ' +
-        controller.RollupTriggerName +
-        ' to be invoked, fails the test if org config or other Apex code prevents this.\n' +
-        '        ' +
-        Utilities.classPrefix() +
-        'RollupService.testHandler(new ' +
-        rollupSummary.ChildObject__c +
-        '());\n' +
-        '    }\n' +
-        '}',
+          ' * Auto Generated and Deployed by the Declarative Lookup Rollup Summaries Tool package (dlrs)\n' +
+          ' **/\n' +
+          '@IsTest\n' +
+          'private class ' +
+          controller.RollupTriggerTestName +
+          '\n' +
+          '{\n' +
+          '    @IsTest\n' +
+          '    private static void testTrigger()\n' +
+          '    {\n' +
+          '        // Force the ' +
+          controller.RollupTriggerName +
+          ' to be invoked, fails the test if org config or other Apex code prevents this.\n' +
+          '        ' +
+          Utilities.classPrefix() +
+          'RollupService.testHandler(new ' +
+          rollupSummary.ChildObject__c +
+          '());\n' +
+          '    }\n' +
+          '}',
         controller.getTriggerTestCode()
       );
       System.assertEquals(
         '<?xml version="1.0" encoding="UTF-8"?>' +
-        '<Package xmlns="http://soap.sforce.com/2006/04/metadata">' +
-        '<types>' +
-        '<members>' +
-        controller.RollupTriggerName +
-        '</members>' +
-        '<name>ApexTrigger</name>' +
-        '</types>' +
-        '<types>' +
-        '<members>' +
-        controller.RollupTriggerTestName +
-        '</members>' +
-        '<name>ApexClass</name>' +
-        '</types>' +
-        '<types>' +
-        '<members>' +
-        controller.RollupParentTriggerName +
-        '</members>' +
-        '<name>ApexTrigger</name>' +
-        '</types>' +
-        '<types>' +
-        '<members>' +
-        controller.RollupParentTriggerTestName +
-        '</members>' +
-        '<name>ApexClass</name>' +
-        '</types>' +
-        '<version>' +
-        RollupController.API_VERSION +
-        '</version>' +
-        '</Package>',
+          '<Package xmlns="http://soap.sforce.com/2006/04/metadata">' +
+          '<types>' +
+          '<members>' +
+          controller.RollupTriggerName +
+          '</members>' +
+          '<name>ApexTrigger</name>' +
+          '</types>' +
+          '<types>' +
+          '<members>' +
+          controller.RollupTriggerTestName +
+          '</members>' +
+          '<name>ApexClass</name>' +
+          '</types>' +
+          '<types>' +
+          '<members>' +
+          controller.RollupParentTriggerName +
+          '</members>' +
+          '<name>ApexTrigger</name>' +
+          '</types>' +
+          '<types>' +
+          '<members>' +
+          controller.RollupParentTriggerTestName +
+          '</members>' +
+          '<name>ApexClass</name>' +
+          '</types>' +
+          '<version>' +
+          controller.apiVersion +
+          '</version>' +
+          '</Package>',
         controller.getPackageXml()
       );
       System.assertEquals(
         '<?xml version="1.0" encoding="UTF-8"?>' +
-        '<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">' +
-        '<apiVersion>' +
-        RollupController.API_VERSION +
-        '</apiVersion>' +
-        '<status>Active</status>' +
-        '</ApexTrigger>',
+          '<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">' +
+          '<apiVersion>' +
+          controller.apiVersion +
+          '</apiVersion>' +
+          '<status>Active</status>' +
+          '</ApexTrigger>',
         controller.getTriggerCodeMetadata()
       );
       System.assertEquals(
         '<?xml version="1.0" encoding="UTF-8"?>' +
-        '<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">' +
-        '<apiVersion>' +
-        RollupController.API_VERSION +
-        '</apiVersion>' +
-        '<status>Active</status>' +
-        '</ApexClass>',
+          '<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">' +
+          '<apiVersion>' +
+          controller.apiVersion +
+          '</apiVersion>' +
+          '<status>Active</status>' +
+          '</ApexClass>',
         controller.getTriggerTestCodeMetadata()
       );
 
@@ -300,8 +299,7 @@ private class RollupControllerTest {
       return;
 
     System.runAs(setupTestUser()) {
-      // Metadata API web Service mock implementation for tests
-      Test.setMock(WebServiceMock.class, new WebServiceMockImpl());
+      setupMocks();
 
       // Test data
       LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
@@ -328,19 +326,19 @@ private class RollupControllerTest {
       );
       System.assertEquals(
         '/**\n' +
-        ' * Auto Generated and Deployed by the Declarative Lookup Rollup Summaries Tool package (dlrs)\n' +
-        ' **/\n' +
-        '@IsTest\n' +
-        'private class ' +
-        controller.RollupTriggerTestName +
-        '\n' +
-        '{\n' +
-        '    @IsTest(SeeAllData=true)\n' +
-        '    private static void testTrigger()\n' +
-        '    {\n' +
-        'System.assertEquals(1,1);\n' +
-        '    }\n' +
-        '}',
+          ' * Auto Generated and Deployed by the Declarative Lookup Rollup Summaries Tool package (dlrs)\n' +
+          ' **/\n' +
+          '@IsTest\n' +
+          'private class ' +
+          controller.RollupTriggerTestName +
+          '\n' +
+          '{\n' +
+          '    @IsTest(SeeAllData=true)\n' +
+          '    private static void testTrigger()\n' +
+          '    {\n' +
+          'System.assertEquals(1,1);\n' +
+          '    }\n' +
+          '}',
         controller.getTriggerTestCode()
       );
     }
@@ -352,8 +350,7 @@ private class RollupControllerTest {
       return;
 
     System.runAs(setupTestUser()) {
-      // Metadata API web Service mock implementation for tests
-      Test.setMock(WebServiceMock.class, new WebServiceMockImpl());
+      setupMocks();
 
       // Custom Metadata test data
       LookupRollupSummary2__mdt rollupSummary = new LookupRollupSummary2__mdt();
@@ -428,21 +425,107 @@ private class RollupControllerTest {
       );
       System.assertEquals(
         '/**\n' +
-        ' * Auto Generated and Deployed by the Declarative Lookup Rollup Summaries Tool package (dlrs)\n' +
-        ' **/\n' +
-        '@IsTest\n' +
-        'private class ' +
-        controller.RollupParentTriggerTestName +
-        '\n' +
-        '{\n' +
-        '    @IsTest(SeeAllData=true)\n' +
-        '    private static void testTrigger()\n' +
-        '    {\n' +
-        'System.assertEquals(1,1);\n' +
-        '    }\n' +
-        '}',
+          ' * Auto Generated and Deployed by the Declarative Lookup Rollup Summaries Tool package (dlrs)\n' +
+          ' **/\n' +
+          '@IsTest\n' +
+          'private class ' +
+          controller.RollupParentTriggerTestName +
+          '\n' +
+          '{\n' +
+          '    @IsTest(SeeAllData=true)\n' +
+          '    private static void testTrigger()\n' +
+          '    {\n' +
+          'System.assertEquals(1,1);\n' +
+          '    }\n' +
+          '}',
         controller.getParentTriggerTestCode()
       );
+    }
+  }
+
+  @IsTest
+  static void testSuccessGetLatestApiVersion() {
+    System.runAs(setupTestUser()) {
+      setupMocks();
+
+      LookupRollupSummary2__mdt rollupSummary = new LookupRollupSummary2__mdt(
+        ParentObject__c = 'Account',
+        ChildObject__c = 'Contact'
+      );
+
+      // Open test context, permits callouts following DML
+      Test.startTest();
+
+      // Assert initial state of controller when the trigger for the child object is deployed
+      RollupController controller = new RollupController(
+        new RollupSummary(rollupSummary)
+      );
+      Test.stopTest();
+      Assert.areEqual('97.0', controller.apiVersion);
+    }
+  }
+
+  @IsTest
+  static void testFail1GetLatestApiVersion() {
+    System.runAs(setupTestUser()) {
+      // service/data mock for getting API version
+      HttpCalloutMockImpl mockCallout = new HttpCalloutMockImpl();
+
+      HTTPResponse res = new HTTPResponse();
+      // choosing to provide very high defaults so we can overcome the fallback value set in the class
+      res.setBody('{"success":"false"}');
+      res.setHeader('Content-Type', 'application/json');
+      res.setStatusCode(401);
+      mockCallout.responses.add(res);
+
+      Test.setMock(HttpCalloutMock.class, mockCallout);
+      Test.setMock(WebServiceMock.class, new WebServiceMockImpl());
+      LookupRollupSummary2__mdt rollupSummary = new LookupRollupSummary2__mdt(
+        ParentObject__c = 'Account',
+        ChildObject__c = 'Contact'
+      );
+
+      // Open test context, permits callouts following DML
+      Test.startTest();
+
+      // Assert initial state of controller when the trigger for the child object is deployed
+      RollupController controller = new RollupController(
+        new RollupSummary(rollupSummary)
+      );
+      Test.stopTest();
+      Assert.areEqual(RollupController.DEF_API_VERSION, controller.apiVersion);
+    }
+  }
+
+  @IsTest
+  static void testFail2GetLatestApiVersion() {
+    System.runAs(setupTestUser()) {
+      // service/data mock for getting API version
+      HttpCalloutMockImpl mockCallout = new HttpCalloutMockImpl();
+
+      HTTPResponse res = new HTTPResponse();
+      // choosing to provide very high defaults so we can overcome the fallback value set in the class
+      res.setBody('this is not json');
+      res.setHeader('Content-Type', 'application/json');
+      res.setStatusCode(200);
+      mockCallout.responses.add(res);
+
+      Test.setMock(HttpCalloutMock.class, mockCallout);
+      Test.setMock(WebServiceMock.class, new WebServiceMockImpl());
+      LookupRollupSummary2__mdt rollupSummary = new LookupRollupSummary2__mdt(
+        ParentObject__c = 'Account',
+        ChildObject__c = 'Contact'
+      );
+
+      // Open test context, permits callouts following DML
+      Test.startTest();
+
+      // Assert initial state of controller when the trigger for the child object is deployed
+      RollupController controller = new RollupController(
+        new RollupSummary(rollupSummary)
+      );
+      Test.stopTest();
+      Assert.areEqual(RollupController.DEF_API_VERSION, controller.apiVersion);
     }
   }
 
@@ -507,8 +590,8 @@ private class RollupControllerTest {
     String uniqueness = DateTime.now() + ':' + Math.random();
     uniqueness += new NullPointerException().getStackTraceString(); //includes the top level test method name without having to pass it
 
-    // officially, there is no Read Only Profile anymore; 
-    // its present for packaging org and scratch org support 
+    // officially, there is no Read Only Profile anymore;
+    // its present for packaging org and scratch org support
     List<Profile> profiles = [
       SELECT id, Name
       FROM Profile
@@ -571,5 +654,32 @@ private class RollupControllerTest {
     insert psa2;
 
     return result;
+  }
+
+  static void setupMocks() {
+    HttpCalloutMockImpl mockCallout = new HttpCalloutMockImpl();
+    HTTPResponse res = new HTTPResponse();
+    // choosing to provide very high API versions so we can overcome the fallback value set in the class
+    res.setBody(
+      '[{"label":"Winter \'97","url":"/services/data/v97.0","version":"97.0"},{"label":"Summer \'95","url":"/services/data/v95.0","version":"95.0"},{"label":"Spring \'96","url":"/services/data/v96.0","version":"96.0"}]'
+    );
+    res.setHeader('Content-Type', 'application/json');
+    res.setStatusCode(200);
+    mockCallout.responses.add(res);
+    Test.setMock(HttpCalloutMock.class, mockCallout);
+    // Mocking for the MetadataService
+    Test.setMock(WebServiceMock.class, new WebServiceMockImpl());
+  }
+
+  private class HttpCalloutMockImpl implements HttpCalloutMock {
+    public List<HTTPRequest> requests = new List<HTTPRequest>();
+    public List<HttpResponse> responses = new List<HttpResponse>();
+    public HTTPResponse respond(HTTPRequest req) {
+      // report the inbound request so it can be validated
+      requests.add(req);
+      // respond with the queued up responses, FIFO
+      // may throw an exception if we don't have any items in the list
+      return responses.remove(0);
+    }
   }
 }

--- a/dlrs/main/classes/RollupControllerTest.cls
+++ b/dlrs/main/classes/RollupControllerTest.cls
@@ -95,7 +95,7 @@ private class RollupControllerTest {
         '<?xml version="1.0" encoding="UTF-8"?>' +
           '<Package xmlns="http://soap.sforce.com/2006/04/metadata">' +
           '<version>' +
-          controller.apiVersion +
+          controller.componentApiVersion +
           '</version>' +
           '</Package>',
         controller.getPackageXml()
@@ -116,7 +116,7 @@ private class RollupControllerTest {
           '<name>ApexClass</name>' +
           '</types>' +
           '<version>' +
-          controller.apiVersion +
+          controller.componentApiVersion +
           '</version>' +
           '</Package>',
         controller.getDestructiveChangesXml()
@@ -125,7 +125,7 @@ private class RollupControllerTest {
         '<?xml version="1.0" encoding="UTF-8"?>' +
           '<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">' +
           '<apiVersion>' +
-          controller.apiVersion +
+          controller.componentApiVersion +
           '</apiVersion>' +
           '<status>Active</status>' +
           '</ApexTrigger>',
@@ -135,7 +135,7 @@ private class RollupControllerTest {
         '<?xml version="1.0" encoding="UTF-8"?>' +
           '<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">' +
           '<apiVersion>' +
-          controller.apiVersion +
+          controller.componentApiVersion +
           '</apiVersion>' +
           '<status>Active</status>' +
           '</ApexClass>',
@@ -262,7 +262,7 @@ private class RollupControllerTest {
           '<name>ApexClass</name>' +
           '</types>' +
           '<version>' +
-          controller.apiVersion +
+          controller.componentApiVersion +
           '</version>' +
           '</Package>',
         controller.getPackageXml()
@@ -271,7 +271,7 @@ private class RollupControllerTest {
         '<?xml version="1.0" encoding="UTF-8"?>' +
           '<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">' +
           '<apiVersion>' +
-          controller.apiVersion +
+          controller.componentApiVersion +
           '</apiVersion>' +
           '<status>Active</status>' +
           '</ApexTrigger>',
@@ -281,7 +281,7 @@ private class RollupControllerTest {
         '<?xml version="1.0" encoding="UTF-8"?>' +
           '<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">' +
           '<apiVersion>' +
-          controller.apiVersion +
+          controller.componentApiVersion +
           '</apiVersion>' +
           '<status>Active</status>' +
           '</ApexClass>',
@@ -460,7 +460,7 @@ private class RollupControllerTest {
         new RollupSummary(rollupSummary)
       );
       Test.stopTest();
-      Assert.areEqual('97.0', controller.apiVersion);
+      Assert.areEqual('97.0', controller.componentApiVersion);
     }
   }
 
@@ -492,7 +492,10 @@ private class RollupControllerTest {
         new RollupSummary(rollupSummary)
       );
       Test.stopTest();
-      Assert.areEqual(RollupController.DEF_API_VERSION, controller.apiVersion);
+      Assert.areEqual(
+        RollupController.FALLBACK_COMPONENT_API_VERSION,
+        controller.componentApiVersion
+      );
     }
   }
 
@@ -524,7 +527,10 @@ private class RollupControllerTest {
         new RollupSummary(rollupSummary)
       );
       Test.stopTest();
-      Assert.areEqual(RollupController.DEF_API_VERSION, controller.apiVersion);
+      Assert.areEqual(
+        RollupController.FALLBACK_COMPONENT_API_VERSION,
+        controller.componentApiVersion
+      );
     }
   }
 


### PR DESCRIPTION
# Changes
Update RollupController (which backs the Trigger Deployment VF page) so it can auto-determine the max supported API version for the current org. This breaks a dependency we have on manually updating the package each release to support new objects.

# Issues Closed
#1373 
