### PR TITLE
Update API v58.0 to v59.0

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -4,7 +4,7 @@ project:
   package:
     name: Declarative Lookup Rollup Summaries Tool
     namespace: dlrs
-    api_version: "58.0"
+    api_version: "59.0"
   git:
     repo_url: https://github.com/SFDO-Community/declarative-lookup-rollup-summaries
     prefix_beta: beta/

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_Answer.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_Answer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_AnswerTest.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_AnswerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_AnyOrder.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_AnyOrder.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_AnyOrderTest.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_AnyOrderTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_ApexMocks.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_ApexMocks.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_ApexMocksConfig.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_ApexMocksConfig.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_ApexMocksTest.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_ApexMocksTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_ApexMocksUtils.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_ApexMocksUtils.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>58.0</apiVersion>
+	<apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_ApexMocksUtilsTest.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_ApexMocksUtilsTest.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>58.0</apiVersion>
+	<apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_ArgumentCaptor.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_ArgumentCaptor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_ArgumentCaptorTest.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_ArgumentCaptorTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_IDGenerator.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_IDGenerator.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>58.0</apiVersion>
+	<apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_IDGeneratorTest.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_IDGeneratorTest.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>58.0</apiVersion>
+	<apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_IMatcher.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_IMatcher.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>58.0</apiVersion>
+	<apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_InOrder.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_InOrder.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_InOrderTest.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_InOrderTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_Inheritor.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_Inheritor.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_InheritorTest.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_InheritorTest.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_InvocationOnMock.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_InvocationOnMock.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_Match.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_Match.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>58.0</apiVersion>
+	<apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_MatchTest.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_MatchTest.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>58.0</apiVersion>
+	<apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_MatcherDefinitions.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_MatcherDefinitions.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>58.0</apiVersion>
+	<apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_MatcherDefinitionsTest.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_MatcherDefinitionsTest.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>58.0</apiVersion>
+	<apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_MatchersReturnValue.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_MatchersReturnValue.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>58.0</apiVersion>
+	<apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_MethodArgValues.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_MethodArgValues.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>58.0</apiVersion>
+	<apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_MethodArgValuesTest.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_MethodArgValuesTest.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>58.0</apiVersion>
+	<apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_MethodCountRecorder.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_MethodCountRecorder.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>58.0</apiVersion>
+	<apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_MethodReturnValue.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_MethodReturnValue.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>58.0</apiVersion>
+	<apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_MethodReturnValueRecorder.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_MethodReturnValueRecorder.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>58.0</apiVersion>
+	<apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_MethodVerifier.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_MethodVerifier.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_Mocks.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_Mocks.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_MyList.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_MyList.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_QualifiedMethod.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_QualifiedMethod.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>58.0</apiVersion>
+	<apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_QualifiedMethodAndArgValues.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_QualifiedMethodAndArgValues.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_QualifiedMethodTest.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_QualifiedMethodTest.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>58.0</apiVersion>
+	<apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_System.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_System.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_SystemTest.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_SystemTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-apexmocks/classes/fflib_VerificationMode.cls-meta.xml
+++ b/dlrs/libs/fflib-apexmocks/classes/fflib_VerificationMode.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_Application.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_Application.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_ApplicationTest.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_ApplicationTest.cls-meta.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>58.0</apiVersion>
+	<apiVersion>59.0</apiVersion>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_ISObjectDomain.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_ISObjectDomain.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_ISObjectSelector.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_ISObjectSelector.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_ISObjectUnitOfWork.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_ISObjectUnitOfWork.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_QueryFactory.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_QueryFactory.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_QueryFactoryTest.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_QueryFactoryTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_SObjectDescribe.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_SObjectDescribe.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_SObjectDescribeTest.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_SObjectDescribeTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_SObjectDomain.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_SObjectDomain.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_SObjectDomainTest.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_SObjectDomainTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_SObjectMocks.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_SObjectMocks.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_SObjectSelector.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_SObjectSelector.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_SObjectSelectorTest.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_SObjectSelectorTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_SObjectUnitOfWork.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_SObjectUnitOfWork.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_SObjectUnitOfWorkTest.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_SObjectUnitOfWorkTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_SecurityUtils.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_SecurityUtils.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_SecurityUtilsTest.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_SecurityUtilsTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_StringBuilder.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_StringBuilder.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/fflib-common/classes/fflib_StringBuilderTest.cls-meta.xml
+++ b/dlrs/libs/fflib-common/classes/fflib_StringBuilderTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/lrengine/classes/LREngine.cls-meta.xml
+++ b/dlrs/libs/lrengine/classes/LREngine.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/lrengine/classes/TestLREngine.cls-meta.xml
+++ b/dlrs/libs/lrengine/classes/TestLREngine.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/metadataservice/classes/MetadataService.cls-meta.xml
+++ b/dlrs/libs/metadataservice/classes/MetadataService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/metadataservice/classes/MetadataServiceTest.cls-meta.xml
+++ b/dlrs/libs/metadataservice/classes/MetadataServiceTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/libs/metadataservice/components/zip.component-meta.xml
+++ b/dlrs/libs/metadataservice/components/zip.component-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexComponent xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <label>Zip</label>
     <packageVersions>
         <majorNumber>1</majorNumber>

--- a/dlrs/libs/metadataservice/components/zipEntry.component-meta.xml
+++ b/dlrs/libs/metadataservice/components/zipEntry.component-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexComponent xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <label>Zip Entry</label>
     <packageVersions>
         <majorNumber>1</majorNumber>

--- a/dlrs/main/aura/optimizer/optimizer.cmp-meta.xml
+++ b/dlrs/main/aura/optimizer/optimizer.cmp-meta.xml
@@ -3,6 +3,6 @@
   xmlns="urn:metadata.tooling.soap.sforce.com"
   fqn="optimizer"
 >
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/dlrs/main/aura/optimizerNotification/optimizerNotification.cmp-meta.xml
+++ b/dlrs/main/aura/optimizerNotification/optimizerNotification.cmp-meta.xml
@@ -3,6 +3,6 @@
   xmlns="urn:metadata.tooling.soap.sforce.com"
   fqn="optimizerNotification"
 >
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/dlrs/main/classes/ApexClassesSelector.cls-meta.xml
+++ b/dlrs/main/classes/ApexClassesSelector.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/ApexTriggersSelector.cls-meta.xml
+++ b/dlrs/main/classes/ApexTriggersSelector.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/AsyncApexJobsSelector.cls-meta.xml
+++ b/dlrs/main/classes/AsyncApexJobsSelector.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/BypassHandler.cls-meta.xml
+++ b/dlrs/main/classes/BypassHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/BypassHandlerTest.cls-meta.xml
+++ b/dlrs/main/classes/BypassHandlerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/CronJobDetailsSelector.cls-meta.xml
+++ b/dlrs/main/classes/CronJobDetailsSelector.cls-meta.xml
@@ -3,6 +3,6 @@
   xmlns="urn:metadata.tooling.soap.sforce.com"
   fqn="CronJobDetailsSelector"
 >
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/CronTriggersSelector.cls-meta.xml
+++ b/dlrs/main/classes/CronTriggersSelector.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/CustomMetadataService.cls-meta.xml
+++ b/dlrs/main/classes/CustomMetadataService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/CustomMetadataServiceTest.cls-meta.xml
+++ b/dlrs/main/classes/CustomMetadataServiceTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/MLRSControllerTest.cls-meta.xml
+++ b/dlrs/main/classes/MLRSControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/ManageLookupRollupSummariesController.cls-meta.xml
+++ b/dlrs/main/classes/ManageLookupRollupSummariesController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/ManageLookupRollupSummariesNewController.cls-meta.xml
+++ b/dlrs/main/classes/ManageLookupRollupSummariesNewController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/ManageLookupRollupSummariesNewTest.cls-meta.xml
+++ b/dlrs/main/classes/ManageLookupRollupSummariesNewTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/MetadataServiceCalloutMock.cls-meta.xml
+++ b/dlrs/main/classes/MetadataServiceCalloutMock.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/OptimizerComponentController.cls-meta.xml
+++ b/dlrs/main/classes/OptimizerComponentController.cls-meta.xml
@@ -3,6 +3,6 @@
   xmlns="urn:metadata.tooling.soap.sforce.com"
   fqn="OptimizerComponentController"
 >
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/OptimizerService.cls-meta.xml
+++ b/dlrs/main/classes/OptimizerService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="OptimizerService">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/OptimizerServiceTest.cls-meta.xml
+++ b/dlrs/main/classes/OptimizerServiceTest.cls-meta.xml
@@ -3,6 +3,6 @@
   xmlns="urn:metadata.tooling.soap.sforce.com"
   fqn="OptimizerServiceTest"
 >
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupActionCalculate.cls-meta.xml
+++ b/dlrs/main/classes/RollupActionCalculate.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupActionCalculateTest.cls-meta.xml
+++ b/dlrs/main/classes/RollupActionCalculateTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupCalculateController.cls-meta.xml
+++ b/dlrs/main/classes/RollupCalculateController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupCalculateControllerTest.cls-meta.xml
+++ b/dlrs/main/classes/RollupCalculateControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupCalculateJob.cls-meta.xml
+++ b/dlrs/main/classes/RollupCalculateJob.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupCalculateJobSchedulable.cls-meta.xml
+++ b/dlrs/main/classes/RollupCalculateJobSchedulable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupController.cls
+++ b/dlrs/main/classes/RollupController.cls
@@ -29,7 +29,7 @@
  **/
 public with sharing class RollupController {
   @TestVisible
-  private static String FALLBACK_COMPONENT_API_VERSION = '58.0';
+  private static String FALLBACK_COMPONENT_API_VERSION = '59.0';
 
   public String ZipData { get; set; }
 

--- a/dlrs/main/classes/RollupController.cls-meta.xml
+++ b/dlrs/main/classes/RollupController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupControllerTest.cls-meta.xml
+++ b/dlrs/main/classes/RollupControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupDmlGuard.cls-meta.xml
+++ b/dlrs/main/classes/RollupDmlGuard.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupDmlGuardTest.cls-meta.xml
+++ b/dlrs/main/classes/RollupDmlGuardTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupJob.cls-meta.xml
+++ b/dlrs/main/classes/RollupJob.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupJobTest.cls-meta.xml
+++ b/dlrs/main/classes/RollupJobTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupScheduledCalculateController.cls-meta.xml
+++ b/dlrs/main/classes/RollupScheduledCalculateController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupScheduledCalculateControllerTest.cls-meta.xml
+++ b/dlrs/main/classes/RollupScheduledCalculateControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupService.cls-meta.xml
+++ b/dlrs/main/classes/RollupService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupServiceException.cls-meta.xml
+++ b/dlrs/main/classes/RollupServiceException.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupServiceTest.cls-meta.xml
+++ b/dlrs/main/classes/RollupServiceTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupServiceTest2.cls-meta.xml
+++ b/dlrs/main/classes/RollupServiceTest2.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupServiceTest3.cls-meta.xml
+++ b/dlrs/main/classes/RollupServiceTest3.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupServiceTest4.cls-meta.xml
+++ b/dlrs/main/classes/RollupServiceTest4.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupServiceTest5.cls-meta.xml
+++ b/dlrs/main/classes/RollupServiceTest5.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupServiceTest6.cls-meta.xml
+++ b/dlrs/main/classes/RollupServiceTest6.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupSummaries.cls-meta.xml
+++ b/dlrs/main/classes/RollupSummaries.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupSummariesSelector.cls-meta.xml
+++ b/dlrs/main/classes/RollupSummariesSelector.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupSummariesSelectorTest.cls-meta.xml
+++ b/dlrs/main/classes/RollupSummariesSelectorTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupSummariesTest.cls-meta.xml
+++ b/dlrs/main/classes/RollupSummariesTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupSummary.cls-meta.xml
+++ b/dlrs/main/classes/RollupSummary.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupSummaryEnhancedController.cls-meta.xml
+++ b/dlrs/main/classes/RollupSummaryEnhancedController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupSummaryEnhancedControllerTest.cls-meta.xml
+++ b/dlrs/main/classes/RollupSummaryEnhancedControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupSummaryLogDeleteController.cls-meta.xml
+++ b/dlrs/main/classes/RollupSummaryLogDeleteController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupSummaryLogDeleteControllerTest.cls-meta.xml
+++ b/dlrs/main/classes/RollupSummaryLogDeleteControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupSummaryScheduleItemsSelector.cls-meta.xml
+++ b/dlrs/main/classes/RollupSummaryScheduleItemsSelector.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupSummaryViewController.cls-meta.xml
+++ b/dlrs/main/classes/RollupSummaryViewController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/RollupSummaryViewControllerTest.cls-meta.xml
+++ b/dlrs/main/classes/RollupSummaryViewControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/TestContext.cls-meta.xml
+++ b/dlrs/main/classes/TestContext.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/Utilities.cls-meta.xml
+++ b/dlrs/main/classes/Utilities.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/WelcomeController.cls-meta.xml
+++ b/dlrs/main/classes/WelcomeController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/classes/WelcomeControllerTest.cls-meta.xml
+++ b/dlrs/main/classes/WelcomeControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/dlrs/main/pages/RollupSummaryView.page-meta.xml
+++ b/dlrs/main/pages/RollupSummaryView.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>RollupSummaryView</label>

--- a/dlrs/main/pages/managelookuprollupsummaries.page-meta.xml
+++ b/dlrs/main/pages/managelookuprollupsummaries.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>managelookuprollupsummaries</label>

--- a/dlrs/main/pages/managelookuprollupsummaries_New.page-meta.xml
+++ b/dlrs/main/pages/managelookuprollupsummaries_New.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata"> 
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <availableInTouch>true</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>managelookuprollupsummaries_New</label>

--- a/dlrs/main/pages/managetrigger.page-meta.xml
+++ b/dlrs/main/pages/managetrigger.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>managetrigger</label>

--- a/dlrs/main/pages/managetriggermdt.page-meta.xml
+++ b/dlrs/main/pages/managetriggermdt.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>managetriggermdt</label>

--- a/dlrs/main/pages/rollupcalculate.page-meta.xml
+++ b/dlrs/main/pages/rollupcalculate.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>rollupcalculate</label>

--- a/dlrs/main/pages/rollupcalculatemdt.page-meta.xml
+++ b/dlrs/main/pages/rollupcalculatemdt.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>rollupcalculatemdt</label>

--- a/dlrs/main/pages/rollupscheduledcalculate.page-meta.xml
+++ b/dlrs/main/pages/rollupscheduledcalculate.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>rollupscheduledcalculate</label>

--- a/dlrs/main/pages/rollupscheduledcalculatemdt.page-meta.xml
+++ b/dlrs/main/pages/rollupscheduledcalculatemdt.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>rollupscheduledcalculatemdt</label>

--- a/dlrs/main/pages/rollupsummaryenhanced.page-meta.xml
+++ b/dlrs/main/pages/rollupsummaryenhanced.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>rollupsummaryenhanced</label>

--- a/dlrs/main/pages/rollupsummaryenhancednew.page-meta.xml
+++ b/dlrs/main/pages/rollupsummaryenhancednew.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>rollupsummaryenhancednew</label>

--- a/dlrs/main/pages/rollupsummarylogdelete.page-meta.xml
+++ b/dlrs/main/pages/rollupsummarylogdelete.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>rollupsummarylogdelete</label>

--- a/dlrs/main/pages/welcome.page-meta.xml
+++ b/dlrs/main/pages/welcome.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>welcome</label>

--- a/dlrs/main/pages/welcometab.page-meta.xml
+++ b/dlrs/main/pages/welcometab.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>welcometab</label>

--- a/dlrs/main/triggers/RollupSummariesTrigger.trigger-meta.xml
+++ b/dlrs/main/triggers/RollupSummariesTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -28,5 +28,5 @@
   ],
   "namespace": "dlrs",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "58.0"
+  "sourceApiVersion": "59.0"
 }

--- a/unpackaged/config/qa/classes/QAHelper.cls-meta.xml
+++ b/unpackaged/config/qa/classes/QAHelper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/unpackaged/config/test_triggers/triggers/UnpackagedRollupServiceTest2Trigger.trigger-meta.xml
+++ b/unpackaged/config/test_triggers/triggers/UnpackagedRollupServiceTest2Trigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/unpackaged/config/test_triggers/triggers/UnpackagedRollupServiceTest3Trigger.trigger-meta.xml
+++ b/unpackaged/config/test_triggers/triggers/UnpackagedRollupServiceTest3Trigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/unpackaged/config/test_triggers/triggers/UnpackagedRollupServiceTest4Trigger.trigger-meta.xml
+++ b/unpackaged/config/test_triggers/triggers/UnpackagedRollupServiceTest4Trigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/unpackaged/config/test_triggers/triggers/UnpackagedRollupServiceTest5Trigger.trigger-meta.xml
+++ b/unpackaged/config/test_triggers/triggers/UnpackagedRollupServiceTest5Trigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/unpackaged/config/test_triggers/triggers/UnpackagedRollupServiceTestTrigger.trigger-meta.xml
+++ b/unpackaged/config/test_triggers/triggers/UnpackagedRollupServiceTestTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>


### PR DESCRIPTION
# Critical Changes

updated API version from v58.0 to v59.0 throughout

# Issues Closed

fixes #1396 - dmlGuard files were still at v56.0 which causes problems with new standard objects