### PR TITLE
Autocomplete Combobox Enhancements

### DIFF
--- a/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.html
+++ b/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.html
@@ -135,9 +135,9 @@
             </template>
 
             <!--ERROR msg, if there is no records..-->
-            <!-- <template if:false={hasRecords}>
-              <li class="slds-listbox__item" style="text-align: center; font-weight: bold;">No Records Found....</li>
-            </template> -->
+            <template if:false={optionsAvailable}>
+              <li class="slds-listbox__item" style="text-align: center; font-weight: bold;">{noResultsMessage}</li>
+            </template>
           </ul>
         </div>
       </div>

--- a/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.html
+++ b/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.html
@@ -44,7 +44,7 @@
             <lightning-input
               type="search"
               data-source="searchInputField"
-              onclick={onToggleDropdown}
+              onfocus={onToggleDropdown}
               onblur={onToggleDropdown}
               onchange={onChangeSearchKey}
               is-loading={isLoading}

--- a/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.html
+++ b/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.html
@@ -98,7 +98,7 @@
           role="listbox"
         >
           <ul class="slds-listbox slds-listbox_vertical" role="presentation">
-            <template for:each={filteredOptions} for:item="option">
+            <template for:each={visibleOptions} for:item="option">
               <li
                 key={option.value}
                 role="presentation"

--- a/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.html
+++ b/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.html
@@ -2,7 +2,6 @@
   <div
     class="slds-form-element slds-combobox_container slds-has-selection"
     style="display: block"
-    onmouseleave={onToggleDropdown}
     data-source="lookupContainer"
   >
     <label class="slds-form-element__label" for="autocomplete-comobobox-id"
@@ -46,6 +45,7 @@
               type="search"
               data-source="searchInputField"
               onclick={onToggleDropdown}
+              onblur={onToggleDropdown}
               onchange={onChangeSearchKey}
               is-loading={isLoading}
               label={label}

--- a/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.html
+++ b/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.html
@@ -52,6 +52,7 @@
               variant="label-hidden"
               placeholder={placeholder}
               value={searchKey}
+              disabled={disabled}
             ></lightning-input>
           </div>
 

--- a/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.html
+++ b/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.html
@@ -44,8 +44,10 @@
             <lightning-input
               type="search"
               data-source="searchInputField"
-              onfocus={onToggleDropdown}
-              onblur={onToggleDropdown}
+              onclick={showDropdown}
+              onfocus={showDropdown}
+              onkeyup={showDropdown}
+              onblur={hideDropdown}
               onchange={onChangeSearchKey}
               is-loading={isLoading}
               label={label}

--- a/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.js
+++ b/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.js
@@ -11,6 +11,7 @@ export default class AutocompleteCombobox extends LightningElement {
   @api helperText;
   @api disabled = false;
   @api searchThreshold = 1;
+  @api searchRequired = false;
 
   @track selectedOption = {};
   @track _value = "";
@@ -58,6 +59,14 @@ export default class AutocompleteCombobox extends LightningElement {
       );
     }
     return styleClass;
+  }
+  get visibleOptions() {
+    if (this.searchRequired) {
+      if (this.searchKey.length >= this.searchThreshold)
+        return this.filteredOptions
+      return [];
+    }
+    return this.filteredOptions;
   }
   // *** EVENT METHODS ***
   onToggleDropdown(event) {

--- a/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.js
+++ b/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.js
@@ -78,7 +78,16 @@ export default class AutocompleteCombobox extends LightningElement {
     return this.visibleOptions.length > 0;
   }
   // *** EVENT METHODS ***
-  onToggleDropdown(event) {
+  showDropdown() {
+    const lookupInputContainer = this.template.querySelector(
+      ".lookupInputContainer"
+    );
+    const clsList = lookupInputContainer.classList;
+    if (!clsList.contains('slds-is-open')) {
+      clsList.add('slds-is-open');
+    }
+  }
+  hideDropdown() {
     const lookupInputContainer = this.template.querySelector(
       ".lookupInputContainer"
     );
@@ -90,8 +99,6 @@ export default class AutocompleteCombobox extends LightningElement {
       setTimeout(() => {
         clsList.remove("slds-is-open");
       }, 310);
-    } else {
-      clsList.add('slds-is-open');
     }
   }
   onChangeSearchKey(event) {

--- a/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.js
+++ b/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.js
@@ -9,6 +9,7 @@ export default class AutocompleteCombobox extends LightningElement {
   @api placeholder;
   @api helperText;
   @api disabled = false;
+  @api searchThreshold = 1;
 
   @track selectedOption = {};
   @track _value = "";
@@ -104,13 +105,17 @@ export default class AutocompleteCombobox extends LightningElement {
   // *** CONTROLLER
   filterOptions(searchKey) {
     try {
-      const lowerCaseSearchKey = searchKey.toLowerCase();
-      this.filteredOptions = this._options.filter(({ value, label }) => {
-        return (
-          value.toLowerCase().includes(lowerCaseSearchKey) ||
-          label.toLowerCase().includes(lowerCaseSearchKey)
-        );
-      });
+      if (searchKey.length >= this.searchThreshold) {
+        const lowerCaseSearchKey = searchKey.toLowerCase();
+        this.filteredOptions = this._options.filter(({ value, label }) => {
+          return (
+            value.toLowerCase().includes(lowerCaseSearchKey) ||
+            label.toLowerCase().includes(lowerCaseSearchKey)
+          );
+        });
+      } else {
+        this.filteredOptions = this._options;
+      }
     } catch (error) {
       this.filteredOptions = this._options;
     }

--- a/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.js
+++ b/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.js
@@ -8,6 +8,7 @@ export default class AutocompleteCombobox extends LightningElement {
   @api label;
   @api placeholder;
   @api helperText;
+  @api disabled = false;
 
   @track selectedOption = {};
   @track _value = "";

--- a/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.js
+++ b/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.js
@@ -1,4 +1,5 @@
 import { LightningElement, api, track } from "lwc";
+import jsLevenshtein from "./js-levenshtein";
 
 const DELAY = 100; // timing in miliseconds
 
@@ -111,6 +112,18 @@ export default class AutocompleteCombobox extends LightningElement {
           return (
             value.toLowerCase().includes(lowerCaseSearchKey) ||
             label.toLowerCase().includes(lowerCaseSearchKey)
+          );
+        }).sort((a, b) => {
+          return (
+            // take the nearest of the Label and value
+            Math.min(
+              jsLevenshtein(lowerCaseSearchKey, a.value.toLowerCase()),
+              jsLevenshtein(lowerCaseSearchKey, a.label.toLowerCase())
+            ) -
+            Math.min(
+              jsLevenshtein(lowerCaseSearchKey, b.value.toLowerCase()),
+              jsLevenshtein(lowerCaseSearchKey, b.label.toLowerCase())
+            )
           );
         });
       } else {

--- a/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.js
+++ b/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.js
@@ -142,7 +142,7 @@ export default class AutocompleteCombobox extends LightningElement {
     try {
       const lowerCaseValue = this._value.toLowerCase();
       this.selectedOption = this._options.find((option) => {
-        return option.value.toLowerCase().includes(lowerCaseValue);
+        return option.value.toLowerCase() === lowerCaseValue;
       });
       this.searchKey = this.selectedOption.label;
     } catch (error) {

--- a/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.js
+++ b/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.js
@@ -13,6 +13,7 @@ export default class AutocompleteCombobox extends LightningElement {
   @api searchThreshold = 1;
   @api searchRequired = false;
   @api maxSearchResults = -1;
+  @api noResultsMessage = 'No Results Found...';
 
   @track selectedOption = {};
   @track _value = "";
@@ -72,6 +73,9 @@ export default class AutocompleteCombobox extends LightningElement {
       return [];
     }
     return results;
+  }
+  get optionsAvailable() {
+    return this.visibleOptions.length > 0;
   }
   // *** EVENT METHODS ***
   onToggleDropdown(event) {

--- a/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.js
+++ b/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.js
@@ -12,6 +12,7 @@ export default class AutocompleteCombobox extends LightningElement {
   @api disabled = false;
   @api searchThreshold = 1;
   @api searchRequired = false;
+  @api maxSearchResults = -1;
 
   @track selectedOption = {};
   @track _value = "";
@@ -61,12 +62,16 @@ export default class AutocompleteCombobox extends LightningElement {
     return styleClass;
   }
   get visibleOptions() {
+    let results = this.filteredOptions;
+    if (this.maxSearchResults > 0) {
+      results = results.slice(0, this.maxSearchResults);
+    }
     if (this.searchRequired) {
       if (this.searchKey.length >= this.searchThreshold)
-        return this.filteredOptions
+        return results
       return [];
     }
-    return this.filteredOptions;
+    return results;
   }
   // *** EVENT METHODS ***
   onToggleDropdown(event) {

--- a/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.js
+++ b/dlrs/main/lwc/autocompleteCombobox/autocompleteCombobox.js
@@ -58,21 +58,19 @@ export default class AutocompleteCombobox extends LightningElement {
   }
   // *** EVENT METHODS ***
   onToggleDropdown(event) {
-    const targetDataSource = event.target.getAttribute("data-source");
     const lookupInputContainer = this.template.querySelector(
       ".lookupInputContainer"
     );
     const clsList = lookupInputContainer.classList;
-    const whichEvent = targetDataSource;
-    switch (whichEvent) {
-      case "searchInputField":
-        clsList.add("slds-is-open");
-        break;
-      case "lookupContainer":
+    if (clsList.contains('slds-is-open')) {
+      // Allow enough time for the click handler of the object list to run before we burn the elements
+      // 310 is chosen because on some mobile devices clicks can take up to 300ms to fire
+      // eslint-disable-next-line @lwc/lwc/no-async-operation
+      setTimeout(() => {
         clsList.remove("slds-is-open");
-        break;
-      default:
-        break;
+      }, 310);
+    } else {
+      clsList.add('slds-is-open');
     }
   }
   onChangeSearchKey(event) {

--- a/dlrs/main/lwc/autocompleteCombobox/js-levenshtein.js
+++ b/dlrs/main/lwc/autocompleteCombobox/js-levenshtein.js
@@ -1,0 +1,100 @@
+// https://github.com/gustf/js-levenshtein/blob/master/index.js
+// MIT License
+function _min(d0, d1, d2, bx, ay) {
+  return d0 < d1 || d2 < d1
+    ? d0 > d2
+      ? d2 + 1
+      : d0 + 1
+    : bx === ay
+    ? d1
+    : d1 + 1;
+}
+
+export default function (a, b) {
+  if (a === b) {
+    return 0;
+  }
+
+  if (a.length > b.length) {
+    let tmp = a;
+    a = b;
+    b = tmp;
+  }
+
+  let la = a.length;
+  let lb = b.length;
+
+  while (la > 0 && a.charCodeAt(la - 1) === b.charCodeAt(lb - 1)) {
+    la--;
+    lb--;
+  }
+
+  let offset = 0;
+
+  while (offset < la && a.charCodeAt(offset) === b.charCodeAt(offset)) {
+    offset++;
+  }
+
+  la -= offset;
+  lb -= offset;
+
+  if (la === 0 || lb < 3) {
+    return lb;
+  }
+
+  let x = 0;
+  let y;
+  let d0;
+  let d1;
+  let d2;
+  let d3;
+  let dd;
+  let dy;
+  let ay;
+  let bx0;
+  let bx1;
+  let bx2;
+  let bx3;
+
+  let vector = [];
+
+  for (y = 0; y < la; y++) {
+    vector.push(y + 1);
+    vector.push(a.charCodeAt(offset + y));
+  }
+
+  let len = vector.length - 1;
+
+  for (; x < lb - 3; ) {
+    bx0 = b.charCodeAt(offset + (d0 = x));
+    bx1 = b.charCodeAt(offset + (d1 = x + 1));
+    bx2 = b.charCodeAt(offset + (d2 = x + 2));
+    bx3 = b.charCodeAt(offset + (d3 = x + 3));
+    dd = x += 4;
+    for (y = 0; y < len; y += 2) {
+      dy = vector[y];
+      ay = vector[y + 1];
+      d0 = _min(dy, d0, d1, bx0, ay);
+      d1 = _min(d0, d1, d2, bx1, ay);
+      d2 = _min(d1, d2, d3, bx2, ay);
+      dd = _min(d2, d3, dd, bx3, ay);
+      vector[y] = dd;
+      d3 = d2;
+      d2 = d1;
+      d1 = d0;
+      d0 = dy;
+    }
+  }
+
+  for (; x < lb; ) {
+    bx0 = b.charCodeAt(offset + (d0 = x));
+    dd = ++x;
+    for (y = 0; y < len; y += 2) {
+      dy = vector[y];
+      vector[y] = dd = _min(dy, d0, dd, bx0, vector[y + 1]);
+      d0 = dy;
+    }
+  }
+
+  return dd;
+}

--- a/dlrs/main/lwc/objectSelector/objectSelector.html
+++ b/dlrs/main/lwc/objectSelector/objectSelector.html
@@ -2,130 +2,17 @@
 for : DLRS; Opensource commons
 -->
 <template>
-  <div class="slds-form-element" data-source="lookupContainer">
-    <div class="slds-combobox_container slds-has-selection">
-      <label class="slds-form-element__label" for="combobox-id-1"
-        >{label}</label
-      >
-      <div
-        class="lookupInputContainer slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click"
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        role="combobox"
-      >
-        <div
-          class="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_left-right"
-          role="none"
-        >
-          <div class="searchBoxWrapper slds-show">
-            <!--Lookup Input Field-->
-            <lightning-input
-              type="search"
-              data-source="searchInputField"
-              onfocus={showResultList}
-              onblur={hideResultList}
-              onchange={handleKeyChange}
-              is-loading={isSearchLoading}
-              value={searchKey}
-              variant="label-hidden"
-              placeholder={placeholder}
-              disabled={isReady}
-            ></lightning-input>
-          </div>
-
-          <!--Lookup Selected record pill container start-->
-          <div class="pillDiv slds-hide">
-            <span class="slds-icon_container slds-combobox__input-entity-icon">
-              <lightning-icon
-                icon-name={selectedRecordIconName}
-                size="x-small"
-                alternative-text="icon"
-              ></lightning-icon>
-            </span>
-            <input
-              type="text"
-              id="combobox-id-1"
-              value={selectedRecord}
-              class="slds-input slds-combobox__input slds-combobox__input-value"
-              readonly
-            />
-            <button
-              class="slds-button slds-button_icon slds-input__icon slds-input__icon_right"
-              title="Remove selected option"
-            >
-              <lightning-icon
-                icon-name="utility:close"
-                size="x-small"
-                alternative-text="close icon"
-                onclick={handleRemove}
-              ></lightning-icon>
-            </button>
-          </div>
-        </div>
-
-        <!-- lookup search result part start-->
-        <div
-          style="margin-top: 0px"
-          id="listbox-id-5"
-          class="slds-dropdown slds-dropdown_length-with-icon-7 slds-dropdown_fluid"
-          role="listbox"
-        >
-          <ul
-            class="slds-listbox slds-listbox_vertical"
-            role="presentation"
-            onclick={handleSelectedRecord}
-          >
-            <template for:each={lstResult} for:item="obj">
-              <li
-                key={obj.fullName}
-                role="presentation"
-                class="slds-listbox__item"
-              >
-                <div
-                  data-objname={obj.fullName}
-                  class="slds-media slds-listbox__option slds-listbox__option_entity slds-listbox__option_has-meta"
-                  role="option"
-                >
-                  <span
-                    style="pointer-events: none"
-                    class="slds-media__figure slds-listbox__option-icon"
-                  >
-                    <span class="slds-icon_container">
-                      <lightning-icon
-                        if:false={obj.iconUrl}
-                        icon-name={obj.iconName}
-                        size="small"
-                        alternative-text="icon"
-                      ></lightning-icon>
-                      <img
-                        if:true={obj.iconUrl}
-                        alt="object icon"
-                        src={obj.iconUrl}
-                        style={obj.iconStyle}
-                      />
-                    </span>
-                  </span>
-                  <span style="pointer-events: none" class="slds-media__body">
-                    <span
-                      class="slds-listbox__option-text slds-listbox__option-text_entity"
-                      >{obj.label} ({obj.fullName})</span
-                    >
-                  </span>
-                </div>
-              </li>
-            </template>
-            <!--ERROR msg, if there is no records..-->
-            <template if:false={lstResult.length}>
-              <li
-                class="slds-listbox__item"
-                style="text-align: center; font-weight: bold"
-              >
-                Search by Object Label or API Name...
-              </li>
-            </template>
-          </ul>
-        </div>
-      </div>
-    </div>
-  </div>
+  <c-autocomplete-combobox
+    label={label}
+    value={selectedRecord}
+    helper-text={helperText}
+    options={objectOptions}
+    placeholder={placeholder}
+    onchangeselection={handleSelectedRecord}
+    disabled={objectsLoading}
+    search-threshold={searchThreshold}
+    search-required={searchRequired}
+    max-search-results={maxSearchResults}
+    no-results-message="Search by Object Label or API Name..."
+  ></c-autocomplete-combobox>
 </template>

--- a/dlrs/main/lwc/objectSelector/objectSelector.js
+++ b/dlrs/main/lwc/objectSelector/objectSelector.js
@@ -1,14 +1,12 @@
 import { LightningElement, api, wire } from "lwc";
 import getAllObjects from "@salesforce/apex/ObjectSelectorController.getParentObjList";
-import jsLevenshtein from "./js-levenshtein";
 import { getObjectInfos } from "lightning/uiObjectInfoApi";
 
-const DELAY = 100; // delay apex callout timing in miliseconds
-const MAX_RESULTS = 5;
 export default class ObjectSelector extends LightningElement {
   // public properties with initial default values
   @api label = "Object";
   @api placeholder = "Select on object";
+  @api helperText = '';
   @api iconName = "standard:custom"; // would be awesome to use the correct icon
   _currentSelection;
   @api
@@ -20,6 +18,9 @@ export default class ObjectSelector extends LightningElement {
     this.selectObject(val);
   }
   // private properties
+  searchThreshold = 3;
+  searchRequired = true;
+  maxSearchResults = 5;
   objectApiNames = [];
   objectIconCache;
   lstResult = []; // to store list of returned records
@@ -28,7 +29,7 @@ export default class ObjectSelector extends LightningElement {
   delayTimeout;
   selectedRecord = "";
   selectedRecordIconName;
-  objects;
+  objects = [];
   preventBlur = false;
   connectedCallback() {
     this.selectedRecordIconName = this.iconName;
@@ -93,142 +94,40 @@ export default class ObjectSelector extends LightningElement {
     }
   }
 
-  get isReady() {
-    return !this.objects;
+  get objectsLoading() {
+    return this.objects.length === 0;
   }
 
-  // update searchKey property on input field change
-  handleKeyChange(event) {
-    window.clearTimeout(this.delayTimeout);
-    const searchKey = event.target.value;
-    // eslint-disable-next-line @lwc/lwc/no-async-operation
-    this.delayTimeout = setTimeout(() => {
-      // Require at least two character for matches
-      if (searchKey.trim().length < 2) {
-        this.lstResult = [];
-        return;
+  get objectOptions() {
+    return this.objects.map(o => {
+      return {
+        value: o.fullName,
+        label: `${o.label} (${o.fullName})`,
+        icon: o.iconName,
       }
-      // constrain results to those containing the text
-      this.lstResult = this.objects.filter(function (obj) {
-        return (
-          obj.fullName.toLowerCase().includes(searchKey.toLowerCase()) ||
-          obj.label.toLowerCase().includes(searchKey.toLowerCase())
-        );
-      });
-      // sort by most similar, either label or API name
-      this.lstResult.sort((a, b) => {
-        return (
-          // take the nearest of the Label and API name
-          Math.min(
-            jsLevenshtein(searchKey.toLowerCase(), `${a.fullName}`),
-            jsLevenshtein(searchKey.toLowerCase(), `${a.label}`)
-          ) -
-          Math.min(
-            jsLevenshtein(searchKey.toLowerCase(), `${b.fullName}`),
-            jsLevenshtein(searchKey.toLowerCase(), `${b.label}`)
-          )
-        );
-      });
-      // limit to the MAX_RESULTS closest matches
-      this.lstResult.splice(MAX_RESULTS);
-    }, DELAY);
+    });
   }
 
-  showResultList() {
-    const lookupInputContainer = this.template.querySelector(
-      ".lookupInputContainer"
-    );
-    const clsList = lookupInputContainer.classList;
-    clsList.add("slds-is-open");
-  }
-
-  hideResultList() {
-    // Allow enough time for the click handler of the object list to run before we burn the elements
-    // 310 is chosen because on some mobile devices clicks can take up to 300ms to fire
-    // eslint-disable-next-line @lwc/lwc/no-async-operation
-    setTimeout(() => {
-      const lookupInputContainer = this.template.querySelector(
-        ".lookupInputContainer"
-      );
-      const clsList = lookupInputContainer.classList;
-      clsList.remove("slds-is-open");
-    }, 310);
-  }
-
-  // method to toggle lookup result section on UI
-  toggleResult(event) {
-    const lookupInputContainer = this.template.querySelector(
-      ".lookupInputContainer"
-    );
-    const clsList = lookupInputContainer.classList;
-    const whichEvent = event.target.getAttribute("data-source");
-    switch (whichEvent) {
-      case "searchInputField":
-        clsList.add("slds-is-open");
-        break;
-      case "lookupContainer":
-        clsList.remove("slds-is-open");
-        break;
-      default:
-        break;
-    }
-  }
-
-  // method to clear selected lookup record
-  handleRemove() {
-    this.searchKey = "";
-    this.selectedRecord = "";
-    this.lstResult = [];
-    this.lookupUpdatehandler(undefined); // update value on parent component as well from helper function
-
-    // remove selected pill and display input field again
-    const searchBoxWrapper = this.template.querySelector(".searchBoxWrapper");
-    if (searchBoxWrapper) {
-      searchBoxWrapper.classList.remove("slds-hide");
-      searchBoxWrapper.classList.add("slds-show");
-      searchBoxWrapper.querySelector("lightning-input").value =
-        this.selectedRecord;
-    }
-    const pillDiv = this.template.querySelector(".pillDiv");
-    if (pillDiv) {
-      pillDiv.classList.remove("slds-show");
-      pillDiv.classList.add("slds-hide");
-    }
-  }
   // method to update selected record from search result
   handleSelectedRecord(event) {
-    const selectedName = event.target.getAttribute("data-objname"); // get selected record Idrd from list
+    const selectedName = event.detail.selectedOption.value; // event.target.getAttribute("data-objname"); // get selected record Idrd from list
     this.selectObject(selectedName);
     this.lookupUpdatehandler(selectedName); // update value on parent component as well from helper function
   }
 
   selectObject(val) {
     if (!val || val.trim().length === 0) {
-      this.handleRemove();
       return;
     }
     // data isn't ready yet, will auto-retry on data loaded
-    if (!this.objects) {
+    if (this.objectsLoading) {
       return;
     }
     const obj = this.objects.find((o) => o.fullName === val);
-    this.selectedRecord = `${obj.label} (${obj.fullName})`;
+    this.selectedRecord = obj.fullName;
     this.selectedRecordIconName = obj.iconName;
-    this.handelSelectRecordHelper(); // helper function to show/hide lookup result container on UI
   }
 
-  /*COMMON HELPER METHOD STARTED*/
-  handelSelectRecordHelper() {
-    this.template
-      .querySelector(".lookupInputContainer")
-      .classList.remove("slds-is-open");
-    const searchBoxWrapper = this.template.querySelector(".searchBoxWrapper");
-    searchBoxWrapper.classList.remove("slds-show");
-    searchBoxWrapper.classList.add("slds-hide");
-    const pillDiv = this.template.querySelector(".pillDiv");
-    pillDiv.classList.remove("slds-hide");
-    pillDiv.classList.add("slds-show");
-  }
   // send selected lookup record to parent component using custom event
   lookupUpdatehandler(value) {
     //Send only the API Name in the event

--- a/dlrs/main/lwc/rollupEditor/rollupEditor.html
+++ b/dlrs/main/lwc/rollupEditor/rollupEditor.html
@@ -123,6 +123,7 @@
               helper-text="The field on the child object that holds the data to rollup"
               value={rollup.FieldToAggregate__c}
               options={childRFieldOptions}
+              disabled={childFieldOptionsPending}
             ></c-autocomplete-combobox>
             <c-rollup-editor-error
               errors={errors.FieldToAggregate__c}
@@ -141,6 +142,7 @@
               options={childRFieldOptions}
               placeholder="Lookup__c"
               onchangeselection={relationshipFieldSelectedHandler}
+              disabled={childFieldOptionsPending}
             ></c-autocomplete-combobox>
             <c-rollup-editor-error
               errors={errors.RelationshipField__c}
@@ -187,6 +189,7 @@
               helper-text="The field on the parent object that will hold the result of the rollup calculation"
               options={parentRFieldOptions}
               value={rollup.AggregateResultField__c}
+              disabled={parentFieldOptionsPending}
             ></c-autocomplete-combobox>
             <c-rollup-editor-error
               errors={errors.AggregateResultField__c}

--- a/dlrs/main/lwc/rollupEditor/rollupEditor.js
+++ b/dlrs/main/lwc/rollupEditor/rollupEditor.js
@@ -155,6 +155,14 @@ export default class RollupEditor extends LightningModal {
     return "Status__c\r\nDays__c";
   }
 
+  get childFieldOptionsPending() {
+    return this.childRFieldOptions.length === 0;
+  }
+
+  get parentFieldOptionsPending() {
+    return this.parentRFieldOptions.length === 0;
+  }
+
   async getRollup() {
     if (!this.rollupName) {
       this.rollup = { ...DEFAULT_ROLLUP_VALUES };


### PR DESCRIPTION
# Critical Changes
- Utilize autocomplete combobox for object selector
- Disable field selection comboboxes in rollup editor when no options are available

# Changes
- Remove onmouseleave behavior from autocomplete combobox
- Decouple show/hide behavior in autocomplete combobox to manage visibility independently
- Add property to configure "disable" behavior on autocomplete combobox
- Add ability to specify a search threshold on the autocomplete combobox
- Display configurable message when no autocomplete options are available
- Add autocomplete combobox property to indicate the maximum number of search results that are displayed
- Add autocomplete combobox property to indicate that search is required to display options
- Update selectOptionByValue function to identify options based on exact match
- Use levenshtein distance to sort search results in autocomplete combobox
