### PR TITLE
Feature/sprint feedback 2024 04

### DIFF
--- a/dlrs/main/classes/RollupEditorController.cls
+++ b/dlrs/main/classes/RollupEditorController.cls
@@ -103,8 +103,25 @@ public with sharing class RollupEditorController {
     RollupSummaries rollupSummaries = new RollupSummaries(mdtRecords);
     rollupSummaries.onValidate();
     Map<String, List<String>> errorMap;
+
     for (RollupSummary rollupSummaryRecord : rollupSummaries.Records) {
       errorMap = collectErrors(rollupSummaryRecord);
+    }
+
+    LookupRollupSummary2__mdt existing = LookupRollupSummary2__mdt.getInstance(
+      lookupConfig.DeveloperName
+    );
+    if (existing != null && existing.Id != lookupConfig.Id) {
+      if (errorMap == null) {
+        errorMap = new Map<String, List<String>>();
+      }
+
+      if (!errorMap.containsKey('developerName')) {
+        errorMap.put('developerName', new List<String>());
+      }
+
+      errorMap.get('developerName')
+        .add('API name already in use by ' + existing.Id);
     }
 
     return errorMap;

--- a/dlrs/main/classes/RollupEditorControllerTest.cls
+++ b/dlrs/main/classes/RollupEditorControllerTest.cls
@@ -94,7 +94,7 @@ public with sharing class RollupEditorControllerTest {
       JSON.serialize(cfg)
     );
     Assert.areEqual(
-      '{"rowLimit":["Row Limit is only supported on Last and Concatentate operators."],"parentObject":["Object does not exist."],"childObject":["Object does not exist."]}',
+      '{"rowLimit":["Row Limit is only supported on Last and Concatenate operators."],"parentObject":["Object does not exist."],"childObject":["Object does not exist."]}',
       JSON.serialize(errors)
     );
   }

--- a/dlrs/main/classes/RollupSummaries.cls
+++ b/dlrs/main/classes/RollupSummaries.cls
@@ -399,7 +399,7 @@ public class RollupSummaries extends fflib_SObjectDomain {
         if (!operationsSupportingRowLimit.contains(operation)) {
           lookupRollupSummary.Fields.RowLimit.addError(
             error(
-              'Row Limit is only supported on Last and Concatentate operators.',
+              'Row Limit is only supported on Last and Concatenate operators.',
               lookupRollupSummary.Record,
               LookupRollupSummary__c.RowLimit__c
             )

--- a/dlrs/main/classes/RollupSummariesTest.cls
+++ b/dlrs/main/classes/RollupSummariesTest.cls
@@ -768,7 +768,7 @@ private class RollupSummariesTest {
     fflib_SObjectDomain.triggerHandler(RollupSummaries.class);
     System.assertEquals(1, fflib_SObjectDomain.Errors.getAll().size());
     System.assertEquals(
-      'Row Limit is only supported on Last and Concatentate operators.',
+      'Row Limit is only supported on Last and Concatenate operators.',
       fflib_SObjectDomain.Errors.getAll()[0].message
     );
     System.assertEquals(

--- a/dlrs/main/lwc/classSchedulerModal/classSchedulerModal.html
+++ b/dlrs/main/lwc/classSchedulerModal/classSchedulerModal.html
@@ -1,5 +1,7 @@
 <template>
-  <lightning-modal-header label={label}></lightning-modal-header>
+  <lightning-modal-header label={label}>
+    <p class="slds-m-top_x-small" lwc:if={description}>{description}</p>
+  </lightning-modal-header>
   <lightning-modal-body>
     <lightning-accordion
       allow-multiple-sections-open
@@ -13,7 +15,7 @@
           <lightning-layout-item size="12">
             <div class="slds-section slds-is-open">
               <h3 class="slds-section__title">
-                Total Scheduled Jobs in the Org
+                Total Scheduled Jobs
                 ({scheduledJobCount}/{totalAllowedScheduledJobs})
               </h3>
               <div class="slds-section__content">
@@ -103,7 +105,13 @@
         <lightning-button
           label="Schedule"
           onclick={handleSchedule}
+          disabled={scheduleIsDisabled}
         ></lightning-button>
+      </lightning-layout-item>
+    </lightning-layout>
+    <lightning-layout horizontal-align="center" lwc:if={errors}>
+      <lightning-layout-item padding="horizontal-small">
+        <span style="color: var(--lwc-colorTextError)">Error: {errors}</span>
       </lightning-layout-item>
     </lightning-layout>
   </lightning-modal-footer>

--- a/dlrs/main/lwc/classSchedulerModal/classSchedulerModal.js
+++ b/dlrs/main/lwc/classSchedulerModal/classSchedulerModal.js
@@ -18,6 +18,8 @@ export default class ClassSchedulerModal extends LightningModal {
   // async apex jobs
   currentSchedule = [];
   isLoadingCurrentSchedule = true;
+  errors;
+
   currentColumns = [
     {
       label: "Name",
@@ -160,6 +162,7 @@ export default class ClassSchedulerModal extends LightningModal {
 
   async handleSchedule() {
     try {
+      this.errors = undefined;
       await scheduleJobs({
         className: this.className,
         newSchedules: this.cronStrings.map((c) => c.cronString)
@@ -171,10 +174,15 @@ export default class ClassSchedulerModal extends LightningModal {
     } catch (error) {
       // TODO: handle the error better
       console.error(error);
+      this.errors = error.body.message;
     }
   }
 
   handleCancel() {
     this.close();
+  }
+
+  get scheduleIsDisabled() {
+    return this.cronStrings.length === 0;
   }
 }

--- a/dlrs/main/lwc/classSchedulerModal/classSchedulerModal.js
+++ b/dlrs/main/lwc/classSchedulerModal/classSchedulerModal.js
@@ -76,6 +76,9 @@ export default class ClassSchedulerModal extends LightningModal {
   @api
   templates;
 
+  @api
+  description;
+
   connectedCallback() {
     this.cronstrue = CronstrueFactory();
     // TODO: when LWS is everywhere then we can go back to loading from Static Resource

--- a/dlrs/main/lwc/cronBuilder/cronBuilder.css
+++ b/dlrs/main/lwc/cronBuilder/cronBuilder.css
@@ -3,3 +3,7 @@ lightning-datatable {
   display: block;
   overflow-y: auto;
 }
+
+.error {
+  color: var(--lwc-colorTextError);
+}

--- a/dlrs/main/lwc/cronBuilder/cronBuilder.html
+++ b/dlrs/main/lwc/cronBuilder/cronBuilder.html
@@ -138,6 +138,15 @@
           </lightning-layout>
         </lightning-tab>
       </lightning-tabset>
+      <div
+        class="error"
+        for:each={errors}
+        for:item="error"
+        key={error}
+        if:true={errors.length}
+      >
+        {error}
+      </div>
     </div>
   </div>
 </template>

--- a/dlrs/main/lwc/cronBuilder/cronBuilder.js
+++ b/dlrs/main/lwc/cronBuilder/cronBuilder.js
@@ -9,6 +9,7 @@ export default class CronBuilder extends LightningElement {
   selectedTemplate = "";
 
   enabledSelectors = [];
+  errors = [];
 
   _templates;
   @api
@@ -305,27 +306,49 @@ export default class CronBuilder extends LightningElement {
   }
 
   buildCronStrings() {
+    this.errors = [];
     // for minute input, each variation requires a differen Cron String
     // all others can have multiple values
+    if (this.selectedMonths.length === 0) {
+      this.errors.push("Must select at least one month");
+    }
     const months =
       this.selectedMonths.length === this.allMonths.length
         ? "*"
         : this.selectedMonths.join(",");
+
+    if (this.selectedDays.length === 0) {
+      this.errors.push("Must select at least one day");
+    }
     const daysOfMonth =
       this.selectedDays.length === this.allDays.length
         ? "*"
         : this.selectedDays.join(",");
+
+    if (this.selectedWeekdays.length === 0) {
+      this.errors.push("Must select at least one weekday");
+    }
     const daysOfWeek =
       this.selectedWeekdays.length === this.allWeekdays.length
         ? "*"
         : this.selectedWeekdays.join(",");
+
+    if (this.selectedHours.length === 0) {
+      this.errors.push("Must select at least one hour");
+    }
     const hours =
       this.selectedHours.length === this.allHours.length
         ? "*"
         : this.selectedHours.join(",");
     const seconds = "0";
-    // TODO: error guards
     const crons = [];
+
+    if (this.selectedMinutes.length === 0) {
+      this.errors.push("Must select at least one minute");
+    }
+    if (this.errors.length > 0) {
+      return crons;
+    }
     // for every minute
     for (let min of this.selectedMinutes) {
       crons.push(

--- a/dlrs/main/lwc/flexiblePath/flexiblePath.css
+++ b/dlrs/main/lwc/flexiblePath/flexiblePath.css
@@ -1,3 +1,7 @@
 * {
   --slds-c-icon-color-foreground-default: white;
 }
+
+.slds-path {
+  min-height: 2rem;
+}

--- a/dlrs/main/lwc/manageRollups/manageRollups.js
+++ b/dlrs/main/lwc/manageRollups/manageRollups.js
@@ -210,7 +210,7 @@ export default class ManageRollups extends NavigationMixin(LightningElement) {
           new ShowToastEvent({
             title: "Deployment Started",
             message:
-              "Started Metadata Record Upates in Deployment " + result.jobId,
+              "Started Metadata Record Updates in Deployment " + result.jobId,
             variant: "info"
           })
         );

--- a/dlrs/main/lwc/rollupEditor/rollupEditor.css
+++ b/dlrs/main/lwc/rollupEditor/rollupEditor.css
@@ -2,6 +2,10 @@
   --slds-c-textarea-sizing-min-height: 300px;
 }
 
+.record-has-errors {
+  color: var(--lwc-colorTextError);
+}
+
 summary {
   cursor: pointer;
 }

--- a/dlrs/main/lwc/rollupEditor/rollupEditor.css
+++ b/dlrs/main/lwc/rollupEditor/rollupEditor.css
@@ -1,3 +1,12 @@
 .testcodearea {
   --slds-c-textarea-sizing-min-height: 300px;
 }
+
+summary {
+  cursor: pointer;
+}
+
+details:not([open]) .summary-down,
+details[open] .summary-right {
+  display: none;
+}

--- a/dlrs/main/lwc/rollupEditor/rollupEditor.html
+++ b/dlrs/main/lwc/rollupEditor/rollupEditor.html
@@ -74,7 +74,7 @@
         ></c-rollup-editor-error>
       </lightning-layout-item>
       <lightning-layout-item size="12" large-device-size="6" lwc:if={rollup.id}>
-        Outstanding Scheduled Items
+        Outstanding Scheduled Items&nbsp;
         <lightning-badge
           label={outstandingScheduledItems.data}
           icon-name={scheduledItemsIcon}

--- a/dlrs/main/lwc/rollupEditor/rollupEditor.html
+++ b/dlrs/main/lwc/rollupEditor/rollupEditor.html
@@ -14,9 +14,6 @@
       <lightning-layout-item>
         <c-rollup-editor-error errors={errors.record}></c-rollup-editor-error>
         <c-rollup-editor-error errors={errors.active}></c-rollup-editor-error>
-        <c-rollup-editor-error
-          errors={scheduledItemsError}
-        ></c-rollup-editor-error>
       </lightning-layout-item>
     </lightning-layout>
     <h3 class="slds-section__title slds-theme--shade">
@@ -538,5 +535,12 @@
       </lightning-layout-item>
     </lightning-layout>
 
+    <lightning-layout horizontal-align="center">
+      <lightning-layout-item lwc:if={hasErrors}>
+        <span class="record-has-errors"
+          >Rollup was unable to save, please review record</span
+        >
+      </lightning-layout-item>
+    </lightning-layout>
   </lightning-modal-footer>
 </template>

--- a/dlrs/main/lwc/rollupEditor/rollupEditor.html
+++ b/dlrs/main/lwc/rollupEditor/rollupEditor.html
@@ -34,6 +34,8 @@
           onblur={onLabelBlurHandler}
           label="Lookup Rollup Summary Label"
           placeholder="My Rollup Name"
+          max-length="40"
+          required
           value={rollup.label}
         ></lightning-input>
         <c-rollup-editor-error errors={errors.label}></c-rollup-editor-error>
@@ -50,6 +52,9 @@
           label="Lookup Rollup Summary API Name"
           placeholder="My_Rollup_Name"
           disabled={rollup.id}
+          max-length="40"
+          required
+          pattern="[a-zA-Z](_?[0-9a-zA-Z])*"
           value={rollup.developerName}
         ></lightning-input>
         <c-rollup-editor-error

--- a/dlrs/main/lwc/rollupEditor/rollupEditor.html
+++ b/dlrs/main/lwc/rollupEditor/rollupEditor.html
@@ -19,435 +19,466 @@
         ></c-rollup-editor-error>
       </lightning-layout-item>
     </lightning-layout>
-    <lightning-accordion
-      allow-multiple-sections-open
-      active-section-name={openAccordianSections}
-    >
-      <lightning-accordion-section name="Information" label="Information">
-        <lightning-layout multiple-rows class="slds-p-horizontal_medium">
-          <lightning-layout-item
-            size="12"
-            large-device-size="6"
-            class="slds-form-element_stacked"
-          >
-            <lightning-input
-              type="text"
-              name="rollup_label"
-              data-name="rollup_label"
-              onblur={onLabelBlurHandler}
-              label="Lookup Rollup Summary Label"
-              placeholder="My Rollup Name"
-              value={rollup.label}
-            ></lightning-input>
-            <c-rollup-editor-error
-              errors={errors.label}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-          <lightning-layout-item
-            size="12"
-            large-device-size="6"
-            class="slds-form-element_stacked"
-          >
-            <lightning-input
-              type="text"
-              name="rollup_developerName"
-              data-name="rollup_developerName"
-              label="Lookup Rollup Summary API Name"
-              placeholder="My_Rollup_Name"
-              disabled={rollup.id}
-              value={rollup.developerName}
-            ></lightning-input>
-            <c-rollup-editor-error
-              errors={errors.developerName}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-          <lightning-layout-item size="12" class="slds-form-element_stacked">
-            <lightning-textarea
-              name="rollup_description"
-              data-name="rollup_description"
-              label="Description"
-              value={rollup.description}
-              maxlength="255"
-            ></lightning-textarea>
-            <c-rollup-editor-error
-              errors={errors.description}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-          <lightning-layout-item
-            size="12"
-            large-device-size="6"
-            lwc:if={rollup.id}
-          >
-            Outstanding Scheduled Items
-            <lightning-badge
-              label={outstandingScheduledItems.data}
-            ></lightning-badge>
-          </lightning-layout-item>
-          <lightning-layout-item
-            size="12"
-            large-device-size="6"
-            lwc:if={rollup.id}
-          >
-            Next Full Calculate
-            <lightning-badge label={nextFullCalculateAt}></lightning-badge>
-          </lightning-layout-item>
-        </lightning-layout>
-      </lightning-accordion-section>
-      <!--Pick Objects-->
-      <lightning-accordion-section name="ChildObject" label="Child Object">
-        <lightning-layout multiple-rows class="slds-p-horizontal_medium">
-          <lightning-layout-item size="12" class="slds-form-element_stacked">
-            <p>
-              Pick the child object, the field that holds your data, and the
-              field that holds the reference to the parent.
-            </p>
-          </lightning-layout-item>
-          <lightning-layout-item
-            size="12"
-            large-device-size="6"
-            class="slds-form-element_stacked"
-          >
-            <c-object-selector
-              label="Child Object"
-              placeholder="Child__c"
-              helper-text="The object that holds the data that needs to be rolled up"
-              current-selection={rollup.childObject}
-              onlookupupdate={childObjectSelected}
-            ></c-object-selector>
-            <c-rollup-editor-error
-              errors={errors.childObject}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-          <lightning-layout-item
-            size="12"
-            large-device-size="6"
-            class="slds-form-element_stacked"
-          >
-            <c-autocomplete-combobox
-              data-name="rollup_fieldToAggregate"
-              label="Field to Aggregate"
-              helper-text="The field on the child object that holds the data to rollup"
-              value={rollup.fieldToAggregate}
-              options={childRFieldOptions}
-              disabled={childFieldOptionsPending}
-            ></c-autocomplete-combobox>
-            <c-rollup-editor-error
-              errors={errors.fieldToAggregate}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-          <lightning-layout-item
-            size="12"
-            large-device-size="6"
-            class="slds-form-element_stacked"
-          >
-            <c-autocomplete-combobox
-              data-name="rollup_relationshipField"
-              label="Relationship Field"
-              value={rollup.relationshipField}
-              helper-text="The field on the child object that holds Id values for the parent object (doesn't have to be a lookup)"
-              options={childRFieldOptions}
-              placeholder="Lookup__c"
-              onchangeselection={relationshipFieldSelectedHandler}
-              disabled={childFieldOptionsPending}
-            ></c-autocomplete-combobox>
-            <c-rollup-editor-error
-              errors={errors.relationshipField}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-        </lightning-layout>
-      </lightning-accordion-section>
-
-      <lightning-accordion-section name="ParentObject" label="Parent Object">
-        <lightning-layout multiple-rows class="slds-p-horizontal_medium">
-          <lightning-layout-item size="12" class="slds-form-element_stacked">
-            <p>
-              Pick the parent object you want to roll up to and the field that
-              will hold the resulting value
-            </p>
-          </lightning-layout-item>
-          <lightning-layout-item
-            size="12"
-            large-device-size="6"
-            class="slds-form-element_stacked"
-          >
-            <c-object-selector
-              label="Parent Object"
-              placeholder="Parent__c"
-              helper-text="The object that will hold the result of the rollup calculation"
-              current-selection={rollup.parentObject}
-              onlookupupdate={parentObjectSelected}
-            ></c-object-selector>
-            <c-rollup-editor-error
-              errors={errors.parentObject}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-
-          <lightning-layout-item
-            size="12"
-            large-device-size="6"
-            class="slds-form-element_stacked"
-          >
-            <c-autocomplete-combobox
-              data-name="rollup_aggregateResultField"
-              label="Aggregate Result Field"
-              helper-text="The field on the parent object that will hold the result of the rollup calculation"
-              options={parentRFieldOptions}
-              value={rollup.aggregateResultField}
-              disabled={parentFieldOptionsPending}
-            ></c-autocomplete-combobox>
-            <c-rollup-editor-error
-              errors={errors.aggregateResultField}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-        </lightning-layout>
-      </lightning-accordion-section>
-      <!--Set Relationship-->
-      <lightning-accordion-section
-        name="Relationship"
-        label="Relationship Criteria"
+    <h3 class="slds-section__title slds-theme--shade">
+      <span class="section-header-title slds-p-horizontal--small"
+        >Information</span
       >
-        <lightning-layout multiple-rows class="slds-p-horizontal_medium">
-          <lightning-layout-item size="12" class="slds-form-element_stacked">
-            <p>Define how child records will be qualified for the rollup</p>
-          </lightning-layout-item>
-          <lightning-layout-item size="12" class="slds-form-element_stacked">
-            <lightning-textarea
-              name="rollup_relationshipCriteria"
-              data-name="rollup_relationshipCriteria"
-              label="Relationship Criteria"
-              field-level-help="The WHERE portion of a SOQL query, records that match the clause will be included in the rollup data"
-              placeholder="Field1__c = TRUE AND Field2__r.Name = 'Parent Value'"
-              value={rollup.relationshipCriteria}
-              maxlength="255"
-            ></lightning-textarea>
-            <c-rollup-editor-error
-              errors={errors.relationshipCriteria}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-          <lightning-layout-item
-            size="12"
-            large-device-size="6"
-            class="slds-form-element_stacked"
-          >
-            <lightning-textarea
-              name="rollup_relationshipCriteriaFields"
-              data-name="rollup_relationshipCriteriaFields"
-              label="Relationship Criteria Fields"
-              field-level-help="Field API names on the child object which when changed will trigger recalculation, each on a new line (Field to Aggregate and Relationship Field are implicitly included)"
-              placeholder={relationshipCriteriaPlaceholder}
-              value={rollup.relationshipCriteriaFields}
-              maxlength="255"
-            ></lightning-textarea>
-            <c-rollup-editor-error
-              errors={errors.relationshipCriteriaFields}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-          <lightning-layout-item
-            size="12"
-            large-device-size="6"
-            class="slds-form-element_stacked"
-          >
-            <h3 class="slds-form-element__label">Aggregate All Rows</h3>
-            <lightning-input
-              type="checkbox"
-              name="rollup_aggregateAllRows"
-              data-name="rollup_aggregateAllRows"
-              label="Include Deleted &amp; Archived Records"
-              field-level-help="If you ONLY want Archived Records add 'IsDeleted = FALSE' to the Relationship Criteria"
-              checked={rollup.aggregateAllRows}
-            ></lightning-input>
-            <c-rollup-editor-error
-              errors={errors.aggregateAllRows}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-        </lightning-layout>
-      </lightning-accordion-section>
-      <!--Summary settings-->
-      <lightning-accordion-section name="RollupDetails" label="Rollup Details">
-        <lightning-layout class="slds-p-horizontal_medium">
-          <lightning-layout-item size="12" class="slds-form-element_stacked">
-            <p>Select the type and configuration of the rollup action</p>
-          </lightning-layout-item>
-        </lightning-layout>
-        <lightning-layout multiple-rows class="slds-p-horizontal_medium">
-          <lightning-layout-item
-            size="12"
-            large-device-size="6"
-            class="slds-form-element_stacked"
-          >
-            <lightning-combobox
-              name="rollup_aggregateOperation"
-              data-name="rollup_aggregateOperation"
-              label="Rollup Type"
-              placeholder="Select"
-              options={aggregateOptions}
-              value={rollup.aggregateOperation}
-              onchange={rollupTypeChangeHandler}
-              required
-            ></lightning-combobox>
-            <c-rollup-editor-error
-              errors={errors.aggregateOperation}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-          <lightning-layout-item
-            size="12"
-            large-device-size="6"
-            class="slds-form-element_stacked"
-          >
-            <lightning-input
-              type="text"
-              name="rollup_concatenateDelimiter"
-              data-name="rollup_concatenateDelimiter"
-              label="Concatenate Delimiter"
-              field-level-help="For Rollup Types Concatenate and Concatenate Distinct, used to separate values in the output"
-              value={rollup.concatenateDelimiter}
-              disabled={shouldDisableConcatDelim}
-            ></lightning-input>
-            <c-rollup-editor-error
-              errors={errors.concatenateDelimiter}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-          <lightning-layout-item
-            size="12"
-            large-device-size="6"
-            class="slds-form-element_stacked"
-          >
-            <lightning-input
-              type="text"
-              name="rollup_fieldToOrderBy"
-              data-name="rollup_fieldToOrderBy"
-              label="Field(s) to Order By"
-              field-level-help="Applies to First, Last, and Concatenate (Distinct) rollups, a SOQL ORDER BY clause, may order by multiple fields ASC or DESC"
-              value={rollup.fieldToOrderBy}
-              disabled={shouldDisableFieldToOrderBy}
-            ></lightning-input>
-            <c-rollup-editor-error
-              errors={errors.fieldToOrderBy}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-          <lightning-layout-item
-            size="12"
-            large-device-size="6"
-            class="slds-form-element_stacked"
-          >
-            <lightning-input
-              type="number"
-              name="rollup_rowLimit"
-              data-name="rollup_rowLimit"
-              label="Row Limit"
-              field-level-help="Applies to Last and Concatentate (Distinct) operators"
-              value={rollup.rowLimit}
-              disabled={shouldDisableRowLimit}
-            ></lightning-input>
-            <c-rollup-editor-error
-              errors={errors.rowLimit}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-        </lightning-layout>
-      </lightning-accordion-section>
-
-      <lightning-accordion-section
-        name="CalculationMode"
-        label="Calculation Mode"
+    </h3>
+    <lightning-layout multiple-rows class="slds-p-horizontal_medium">
+      <lightning-layout-item
+        size="12"
+        large-device-size="6"
+        class="slds-form-element_stacked"
       >
-        <lightning-layout multiple-rows class="slds-p-horizontal_medium">
-          <lightning-layout-item
-            size="12"
-            large-device-size="6"
-            class="slds-form-element_stacked"
-          >
-            <lightning-combobox
-              name="rollup_calculationMode"
-              data-name="rollup_calculationMode"
-              label="Calculation Mode"
-              field-level-help="Control how DLRS checks for changes and when/how the parent record is updated"
-              placeholder="Select"
-              options={calculationModes}
-              value={rollup.calculationMode}
-              onchange={calculationModeChangeHandler}
-              required
-            ></lightning-combobox>
-            <c-rollup-editor-error
-              errors={errors.calculationMode}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-          <lightning-layout-item
-            size="12"
-            large-device-size="6"
-            class="slds-form-element_stacked"
-          >
-            <lightning-combobox
-              name="rollup_calculationSharingMode"
-              data-name="rollup_calculationSharingMode"
-              label="Calculation Sharing Mode"
-              field-level-help="Choose which Apex Sharing mode should be used when the rollup value is calculated"
-              placeholder="Select"
-              options={calculationSharingModes}
-              value={rollup.calculationSharingMode}
-              required
-            ></lightning-combobox>
-            <c-rollup-editor-error
-              errors={errors.calculationSharingMode}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-        </lightning-layout>
-      </lightning-accordion-section>
+        <lightning-input
+          type="text"
+          name="rollup_label"
+          data-name="rollup_label"
+          onblur={onLabelBlurHandler}
+          label="Lookup Rollup Summary Label"
+          placeholder="My Rollup Name"
+          value={rollup.label}
+        ></lightning-input>
+        <c-rollup-editor-error errors={errors.label}></c-rollup-editor-error>
+      </lightning-layout-item>
+      <lightning-layout-item
+        size="12"
+        large-device-size="6"
+        class="slds-form-element_stacked"
+      >
+        <lightning-input
+          type="text"
+          name="rollup_developerName"
+          data-name="rollup_developerName"
+          label="Lookup Rollup Summary API Name"
+          placeholder="My_Rollup_Name"
+          disabled={rollup.id}
+          value={rollup.developerName}
+        ></lightning-input>
+        <c-rollup-editor-error
+          errors={errors.developerName}
+        ></c-rollup-editor-error>
+      </lightning-layout-item>
+      <lightning-layout-item size="12" class="slds-form-element_stacked">
+        <lightning-textarea
+          name="rollup_description"
+          data-name="rollup_description"
+          label="Description"
+          value={rollup.description}
+          maxlength="255"
+        ></lightning-textarea>
+        <c-rollup-editor-error
+          errors={errors.description}
+        ></c-rollup-editor-error>
+      </lightning-layout-item>
+      <lightning-layout-item size="12" large-device-size="6" lwc:if={rollup.id}>
+        Outstanding Scheduled Items
+        <lightning-badge
+          label={outstandingScheduledItems.data}
+          icon-name={scheduledItemsIcon}
+        ></lightning-badge
+        >&nbsp;
+        <lightning-helptext
+          content="Scheduled items for this rollup created at least two days ago and not yet processed, possible indicator that RollupJob scheduled Apex may not be running correctly"
+        ></lightning-helptext>
+      </lightning-layout-item>
+      <lightning-layout-item size="12" large-device-size="6" lwc:if={rollup.id}>
+        Next Full Calculate&nbsp;
+        <lightning-formatted-date-time
+          class="slds-badge"
+          value={nextFullCalculateAt}
+          year="numeric"
+          month="numeric"
+          day="numeric"
+          hour="numeric"
+          minute="2-digit"
+          lwc:if={nextFullCalculateAt}
+        ></lightning-formatted-date-time>
+        <lightning-badge label="Not Scheduled" lwc:else></lightning-badge>
+      </lightning-layout-item>
+    </lightning-layout>
 
-      <lightning-accordion-section name="Advanced" label="Advanced">
-        <lightning-layout multiple-rows class="slds-p-horizontal_medium">
-          <lightning-layout-item
-            size="12"
-            large-device-size="6"
-            class="slds-form-element_stacked"
+    <!--Pick Objects-->
+
+    <h3 class="slds-section__title slds-theme--shade">
+      <span class="section-header-title slds-p-horizontal--small"
+        >Child Object</span
+      >
+    </h3>
+    <lightning-layout multiple-rows class="slds-p-horizontal_medium">
+      <lightning-layout-item size="12" class="slds-form-element_stacked">
+        <p>
+          Select the child object, the field that contains the data, and the
+          field that contains the reference to the parent object.
+        </p>
+      </lightning-layout-item>
+      <lightning-layout-item
+        size="12"
+        large-device-size="6"
+        class="slds-form-element_stacked"
+      >
+        <c-object-selector
+          label="Child Object"
+          placeholder="Child__c"
+          helper-text="The object that holds the data that needs to be rolled up"
+          current-selection={rollup.childObject}
+          onlookupupdate={childObjectSelected}
+        ></c-object-selector>
+        <c-rollup-editor-error
+          errors={errors.childObject}
+        ></c-rollup-editor-error>
+      </lightning-layout-item>
+      <lightning-layout-item
+        size="12"
+        large-device-size="6"
+        class="slds-form-element_stacked"
+      >
+        <c-autocomplete-combobox
+          data-name="rollup_fieldToAggregate"
+          label="Field to Aggregate"
+          helper-text="The field on the child object that holds the data to rollup"
+          value={rollup.fieldToAggregate}
+          options={childRFieldOptions}
+          disabled={childFieldOptionsPending}
+        ></c-autocomplete-combobox>
+        <c-rollup-editor-error
+          errors={errors.fieldToAggregate}
+        ></c-rollup-editor-error>
+      </lightning-layout-item>
+      <lightning-layout-item
+        size="12"
+        large-device-size="6"
+        class="slds-form-element_stacked"
+      >
+        <c-autocomplete-combobox
+          data-name="rollup_relationshipField"
+          label="Relationship Field"
+          value={rollup.relationshipField}
+          helper-text="The field on the child object that holds Id values for the parent object (doesn't have to be a lookup)"
+          options={childRFieldOptions}
+          placeholder="Lookup__c"
+          onchangeselection={relationshipFieldSelectedHandler}
+          disabled={childFieldOptionsPending}
+        ></c-autocomplete-combobox>
+        <c-rollup-editor-error
+          errors={errors.relationshipField}
+        ></c-rollup-editor-error>
+      </lightning-layout-item>
+    </lightning-layout>
+
+    <h3 class="slds-section__title slds-theme--shade">
+      <span class="section-header-title slds-p-horizontal--small"
+        >Parent Object</span
+      >
+    </h3>
+    <lightning-layout multiple-rows class="slds-p-horizontal_medium">
+      <lightning-layout-item size="12" class="slds-form-element_stacked">
+        <p>
+          Select the parent object to rollup to and the field that will receive
+          the resulting value
+        </p>
+      </lightning-layout-item>
+      <lightning-layout-item
+        size="12"
+        large-device-size="6"
+        class="slds-form-element_stacked"
+      >
+        <c-object-selector
+          label="Parent Object"
+          placeholder="Parent__c"
+          helper-text="The object that will hold the result of the rollup calculation"
+          current-selection={rollup.parentObject}
+          onlookupupdate={parentObjectSelected}
+        ></c-object-selector>
+        <c-rollup-editor-error
+          errors={errors.parentObject}
+        ></c-rollup-editor-error>
+      </lightning-layout-item>
+
+      <lightning-layout-item
+        size="12"
+        large-device-size="6"
+        class="slds-form-element_stacked"
+      >
+        <c-autocomplete-combobox
+          data-name="rollup_aggregateResultField"
+          label="Aggregate Result Field"
+          helper-text="The field on the parent object that will hold the result of the rollup calculation"
+          options={parentRFieldOptions}
+          value={rollup.aggregateResultField}
+          disabled={parentFieldOptionsPending}
+        ></c-autocomplete-combobox>
+        <c-rollup-editor-error
+          errors={errors.aggregateResultField}
+        ></c-rollup-editor-error>
+      </lightning-layout-item>
+    </lightning-layout>
+    <!--Set Relationship-->
+
+    <h3 class="slds-section__title slds-theme--shade">
+      <span class="section-header-title slds-p-horizontal--small"
+        >Relationship Criteria</span
+      >
+    </h3>
+    <lightning-layout multiple-rows class="slds-p-horizontal_medium">
+      <lightning-layout-item size="12" class="slds-form-element_stacked">
+        <p>Define how child records will be qualified for the rollup</p>
+      </lightning-layout-item>
+      <lightning-layout-item size="12" class="slds-form-element_stacked">
+        <lightning-textarea
+          name="rollup_relationshipCriteria"
+          data-name="rollup_relationshipCriteria"
+          label="Relationship Criteria"
+          field-level-help="The WHERE portion of a SOQL query, records that match the clause will be included in the rollup data"
+          placeholder="Example_Field1__c = TRUE AND Example_Field2__r.Name = 'Parent Value'"
+          value={rollup.relationshipCriteria}
+          maxlength="255"
+        ></lightning-textarea>
+        <c-rollup-editor-error
+          errors={errors.relationshipCriteria}
+        ></c-rollup-editor-error>
+      </lightning-layout-item>
+      <lightning-layout-item
+        size="12"
+        large-device-size="6"
+        class="slds-form-element_stacked"
+      >
+        <lightning-textarea
+          name="rollup_relationshipCriteriaFields"
+          data-name="rollup_relationshipCriteriaFields"
+          label="Relationship Criteria Fields"
+          field-level-help="Field API names on the child object which when changed will trigger recalculation, each on a new line (Field to Aggregate and Relationship Field are implicitly included)"
+          placeholder={relationshipCriteriaPlaceholder}
+          value={rollup.relationshipCriteriaFields}
+          maxlength="255"
+        ></lightning-textarea>
+        <c-rollup-editor-error
+          errors={errors.relationshipCriteriaFields}
+        ></c-rollup-editor-error>
+      </lightning-layout-item>
+      <lightning-layout-item
+        size="12"
+        large-device-size="6"
+        class="slds-form-element_stacked"
+      >
+        <h3 class="slds-form-element__label">Aggregate All Rows</h3>
+        <lightning-input
+          type="checkbox"
+          name="rollup_aggregateAllRows"
+          data-name="rollup_aggregateAllRows"
+          label="Include Deleted &amp; Archived Records"
+          field-level-help="If you ONLY want Archived Records add 'IsDeleted = FALSE' to the Relationship Criteria"
+          checked={rollup.aggregateAllRows}
+        ></lightning-input>
+        <c-rollup-editor-error
+          errors={errors.aggregateAllRows}
+        ></c-rollup-editor-error>
+      </lightning-layout-item>
+    </lightning-layout>
+    <!--Summary settings-->
+
+    <h3 class="slds-section__title slds-theme--shade">
+      <span class="section-header-title slds-p-horizontal--small"
+        >Rollup Details</span
+      >
+    </h3>
+    <lightning-layout class="slds-p-horizontal_medium">
+      <lightning-layout-item size="12" class="slds-form-element_stacked">
+        <p>Select the type and configuration of the rollup action</p>
+      </lightning-layout-item>
+    </lightning-layout>
+    <lightning-layout multiple-rows class="slds-p-horizontal_medium">
+      <lightning-layout-item
+        size="12"
+        large-device-size="6"
+        class="slds-form-element_stacked"
+      >
+        <lightning-combobox
+          name="rollup_aggregateOperation"
+          data-name="rollup_aggregateOperation"
+          label="Rollup Type"
+          placeholder="Select"
+          options={aggregateOptions}
+          value={rollup.aggregateOperation}
+          onchange={rollupTypeChangeHandler}
+          required
+        ></lightning-combobox>
+        <c-rollup-editor-error
+          errors={errors.aggregateOperation}
+        ></c-rollup-editor-error>
+      </lightning-layout-item>
+      <lightning-layout-item
+        size="12"
+        large-device-size="6"
+        class="slds-form-element_stacked"
+      >
+        <lightning-input
+          type="text"
+          name="rollup_concatenateDelimiter"
+          data-name="rollup_concatenateDelimiter"
+          label="Concatenate Delimiter"
+          field-level-help="For Rollup Types Concatenate and Concatenate Distinct, used to separate values in the output"
+          value={rollup.concatenateDelimiter}
+          disabled={shouldDisableConcatDelim}
+        ></lightning-input>
+        <c-rollup-editor-error
+          errors={errors.concatenateDelimiter}
+        ></c-rollup-editor-error>
+      </lightning-layout-item>
+      <lightning-layout-item
+        size="12"
+        large-device-size="6"
+        class="slds-form-element_stacked"
+      >
+        <lightning-input
+          type="text"
+          name="rollup_fieldToOrderBy"
+          data-name="rollup_fieldToOrderBy"
+          label="Field(s) to Order By"
+          field-level-help="Applies to First, Last, and Concatenate (Distinct) rollups, a SOQL ORDER BY clause, may order by multiple fields ASC or DESC"
+          value={rollup.fieldToOrderBy}
+          disabled={shouldDisableFieldToOrderBy}
+        ></lightning-input>
+        <c-rollup-editor-error
+          errors={errors.fieldToOrderBy}
+        ></c-rollup-editor-error>
+      </lightning-layout-item>
+      <lightning-layout-item
+        size="12"
+        large-device-size="6"
+        class="slds-form-element_stacked"
+      >
+        <lightning-input
+          type="number"
+          name="rollup_rowLimit"
+          data-name="rollup_rowLimit"
+          label="Row Limit"
+          field-level-help="Applies to Last and Concatenate (Distinct) operators"
+          value={rollup.rowLimit}
+          disabled={shouldDisableRowLimit}
+        ></lightning-input>
+        <c-rollup-editor-error errors={errors.rowLimit}></c-rollup-editor-error>
+      </lightning-layout-item>
+    </lightning-layout>
+
+    <h3 class="slds-section__title slds-theme--shade">
+      <span class="section-header-title slds-p-horizontal--small"
+        >Calculation Mode</span
+      >
+    </h3>
+    <lightning-layout multiple-rows class="slds-p-horizontal_medium">
+      <lightning-layout-item
+        size="12"
+        large-device-size="6"
+        class="slds-form-element_stacked"
+      >
+        <lightning-combobox
+          name="rollup_calculationMode"
+          data-name="rollup_calculationMode"
+          label="Calculation Mode"
+          field-level-help="Control how DLRS checks for changes and when/how the parent record is updated"
+          placeholder="Select"
+          options={calculationModes}
+          value={rollup.calculationMode}
+          onchange={calculationModeChangeHandler}
+          required
+        ></lightning-combobox>
+        <c-rollup-editor-error
+          errors={errors.calculationMode}
+        ></c-rollup-editor-error>
+      </lightning-layout-item>
+      <lightning-layout-item
+        size="12"
+        large-device-size="6"
+        class="slds-form-element_stacked"
+      >
+        <lightning-combobox
+          name="rollup_calculationSharingMode"
+          data-name="rollup_calculationSharingMode"
+          label="Calculation Sharing Mode"
+          field-level-help="Choose which Apex Sharing mode should be used when the rollup value is calculated"
+          placeholder="Select"
+          options={calculationSharingModes}
+          value={rollup.calculationSharingMode}
+          required
+        ></lightning-combobox>
+        <c-rollup-editor-error
+          errors={errors.calculationSharingMode}
+        ></c-rollup-editor-error>
+      </lightning-layout-item>
+    </lightning-layout>
+
+    <details>
+      <summary>
+        <h3 class="slds-section__title slds-theme--shade">
+          <span class="section-header-title slds-p-horizontal--small"
+            ><lightning-icon
+              icon-name="utility:chevronright"
+              size="x-small"
+              class="summary-right"
+            ></lightning-icon>
+            <lightning-icon
+              icon-name="utility:chevrondown"
+              size="x-small"
+              class="summary-down"
+            ></lightning-icon
+            >Advanced</span
           >
-            <lightning-textarea
-              name="rollup_testCode"
-              data-name="rollup_testCode"
-              label="Test Code (Child Object)"
-              field-level-help="Define a custom method body to be used in the generated test class"
-              value={rollup.testCode}
-              maxlength="131072"
-              class="testcodearea"
-            ></lightning-textarea>
-            <c-rollup-editor-error
-              errors={errors.testCode}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-          <lightning-layout-item
-            size="12"
-            large-device-size="6"
-            class="slds-form-element_stacked"
-          >
-            <lightning-textarea
-              name="rollup_testCodeParent"
-              data-name="rollup_testCodeParent"
-              label="Test Code (Parent Object)"
-              field-level-help="Define a custom method body to be used in the generated test class"
-              value={rollup.testCodeParent}
-              maxlength="131072"
-              class="testcodearea"
-            ></lightning-textarea>
-            <c-rollup-editor-error
-              errors={errors.testCodeParent}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-          <lightning-layout-item class="slds-form-element_stacked">
-            <lightning-input
-              type="checkbox"
-              name="rollup_testCodeSeeAllData"
-              data-name="rollup_testCodeSeeAllData"
-              label="Test Code Sees All Data?"
-              checked={rollup.testCodeSeeAllData}
-              variant="label-stacked"
-              style="padding-left: 0px !important"
-            ></lightning-input>
-            <c-rollup-editor-error
-              errors={errors.testCodeSeeAllData}
-            ></c-rollup-editor-error>
-          </lightning-layout-item>
-        </lightning-layout>
-      </lightning-accordion-section>
-    </lightning-accordion>
+        </h3>
+      </summary>
+      <lightning-layout multiple-rows class="slds-p-horizontal_medium">
+        <lightning-layout-item
+          size="12"
+          large-device-size="6"
+          class="slds-form-element_stacked"
+        >
+          <lightning-textarea
+            name="rollup_testCode"
+            data-name="rollup_testCode"
+            label="Test Code (Child Object)"
+            field-level-help="Define a custom method body to be used in the generated test class"
+            value={rollup.testCode}
+            maxlength="131072"
+            class="testcodearea"
+          ></lightning-textarea>
+          <c-rollup-editor-error
+            errors={errors.testCode}
+          ></c-rollup-editor-error>
+        </lightning-layout-item>
+        <lightning-layout-item
+          size="12"
+          large-device-size="6"
+          class="slds-form-element_stacked"
+        >
+          <lightning-textarea
+            name="rollup_testCodeParent"
+            data-name="rollup_testCodeParent"
+            label="Test Code (Parent Object)"
+            field-level-help="Define a custom method body to be used in the generated test class"
+            value={rollup.testCodeParent}
+            maxlength="131072"
+            class="testcodearea"
+          ></lightning-textarea>
+          <c-rollup-editor-error
+            errors={errors.testCodeParent}
+          ></c-rollup-editor-error>
+        </lightning-layout-item>
+        <lightning-layout-item class="slds-form-element_stacked">
+          <lightning-input
+            type="checkbox"
+            name="rollup_testCodeSeeAllData"
+            data-name="rollup_testCodeSeeAllData"
+            label="Test Code Sees All Data?"
+            checked={rollup.testCodeSeeAllData}
+            variant="label-stacked"
+            style="padding-left: 0px !important"
+          ></lightning-input>
+          <c-rollup-editor-error
+            errors={errors.testCodeSeeAllData}
+          ></c-rollup-editor-error>
+        </lightning-layout-item>
+      </lightning-layout>
+    </details>
   </lightning-modal-body>
   <lightning-modal-footer>
     <lightning-layout horizontal-align="center">
@@ -506,5 +537,6 @@
         </lightning-button-group>
       </lightning-layout-item>
     </lightning-layout>
+
   </lightning-modal-footer>
 </template>

--- a/dlrs/main/lwc/rollupEditor/rollupEditor.js
+++ b/dlrs/main/lwc/rollupEditor/rollupEditor.js
@@ -139,10 +139,9 @@ export default class RollupEditor extends LightningModal {
         });
 
         this.rollupId = this.rollup.id;
-        this.nextFullCalculateAt =
-          (await getScheduledFullCalculates({
-            lookupId: this.rollupId
-          })) ?? "Not Scheduled";
+        this.nextFullCalculateAt = await getScheduledFullCalculates({
+          lookupID: this.rollupId
+        });
       } catch (error) {
         this.errors.record = [error.message];
       }

--- a/dlrs/main/lwc/rollupEditor/rollupEditor.js
+++ b/dlrs/main/lwc/rollupEditor/rollupEditor.js
@@ -66,15 +66,6 @@ export default class RollupEditor extends LightningModal {
   @wire(getOutstandingScheduledItemsForLookup, { lookupID: "$rollupId" })
   outstandingScheduledItems;
 
-  openAccordianSections = [
-    "Information",
-    "ChildObject",
-    "ParentObject",
-    "Relationship",
-    "RollupDetails",
-    "CalculationMode"
-  ];
-
   @track
   rollup = { ...DEFAULT_ROLLUP_VALUES };
   errors = {};

--- a/dlrs/main/lwc/rollupEditor/rollupEditor.js
+++ b/dlrs/main/lwc/rollupEditor/rollupEditor.js
@@ -109,17 +109,12 @@ export default class RollupEditor extends LightningModal {
     return this.rollup.id && this.rollup.active;
   }
 
-  get scheduledItemsError() {
-    if (
-      !this.outstandingScheduledItems ||
-      !this.outstandingScheduledItems?.data
-    ) {
-      return null;
+  get scheduledItemsIcon() {
+    if (!this.rollup.id || !this.outstandingScheduledItems?.data) {
+      return "";
     }
 
-    return [
-      `This rollup has ${this.outstandingScheduledItems.data} outstanding scheduled items`
-    ];
+    return "utility:warning";
   }
 
   get relationshipCriteriaPlaceholder() {

--- a/dlrs/main/lwc/rollupEditor/rollupEditor.js
+++ b/dlrs/main/lwc/rollupEditor/rollupEditor.js
@@ -57,6 +57,33 @@ const STEP_TEMPLATES = Object.freeze({
   other: [STEPS.configure, STEPS.activate]
 });
 
+export const CLASS_SCHEDULER_CONFIG = {
+  label: "Process Scheduled Items",
+  description:
+    "Manage RollupJob schedules to process all pending Scheduled Item records for all rollups",
+  className: "RollupJob",
+  size: "small",
+  templates: [
+    {
+      label: "Once Every Day",
+      value: "daily",
+      selectors: ["single-hour"],
+      presets: { hours: ["3"] }
+    },
+    {
+      label: "Once Every Hour",
+      value: "hourly",
+      selectors: ["single-minute"]
+    },
+    {
+      label: "Every 15 minutes",
+      value: "every15",
+      selectors: [],
+      presets: { minutes: ["0", "15", "30", "45"] }
+    }
+  ]
+};
+
 export default class RollupEditor extends LightningModal {
   isLoading = false;
   childTriggerIsDeployed = false;
@@ -84,9 +111,7 @@ export default class RollupEditor extends LightningModal {
   }
   @api
   set rollupName(val) {
-    this.errors = {}; // clear any existing error
     this._rollupName = val;
-    this.getRollup();
   }
 
   get cardHeader() {
@@ -134,9 +159,17 @@ export default class RollupEditor extends LightningModal {
       this.rollup = { ...DEFAULT_ROLLUP_VALUES };
     } else {
       try {
-        this.rollup = await getRollupConfig({
-          rollupName: this.rollupName
-        });
+        this.rollup = window.sessionStorage.getItem(this.rollupName);
+        if (this.rollup) {
+          window.sessionStorage.removeItem(this.rollupName);
+          this.rollup = JSON.parse(this.rollup);
+        } else {
+          // necessary to prevent HTML from trying to access a null object
+          this.rollup = { ...DEFAULT_ROLLUP_VALUES };
+          this.rollup = await getRollupConfig({
+            rollupName: this.rollupName
+          });
+        }
 
         this.rollupId = this.rollup.id;
         this.nextFullCalculateAt = await getScheduledFullCalculates({
@@ -226,8 +259,10 @@ export default class RollupEditor extends LightningModal {
   }
 
   cloneClickHandler() {
-    this.rollup.developerName = undefined;
-    this.rollup.id = undefined;
+    delete this.rollup.developerName;
+    delete this.rollup.id;
+    this.rollupId = undefined;
+    this.errors = {};
   }
 
   deleteClickHandler() {
@@ -258,41 +293,19 @@ export default class RollupEditor extends LightningModal {
         this.activateClickHandler();
         break;
       case "scheduleJob":
-        await ClassSchedulerModal.open({
-          label: "Schedule Rollup Job",
-          description: "Scheduled RollupJob to process Scheduled Items",
-          className: "RollupJob",
-          size: "small",
-          templates: [
-            {
-              label: "Once Every Day",
-              value: "daily",
-              selectors: ["single-hour"],
-              presets: { hours: ["3"] }
-            },
-            {
-              label: "Once Every Hour",
-              value: "hourly",
-              selectors: ["single-minute"]
-            },
-            {
-              label: "Every 15 minutes",
-              value: "every15",
-              selectors: [],
-              presets: { minutes: ["0", "15", "30", "45"] }
-            }
-          ]
-        }).then((results) => {
-          if (results) {
-            try {
-              const evt = new ShowToastEvent(results);
-              this.dispatchEvent(evt);
-            } catch (err) {
-              // known issue with Lighting Locker can cause this to fail
-              console.error("Failed to create toast with outcome", err);
+        await ClassSchedulerModal.open(CLASS_SCHEDULER_CONFIG).then(
+          (results) => {
+            if (results) {
+              try {
+                const evt = new ShowToastEvent(results);
+                this.dispatchEvent(evt);
+              } catch (err) {
+                // known issue with Lighting Locker can cause this to fail
+                console.error("Failed to create toast with outcome", err);
+              }
             }
           }
-        });
+        );
         // recalculate Path after Schedule is created
         this.configureSteps();
         break;
@@ -380,7 +393,6 @@ export default class RollupEditor extends LightningModal {
       return;
     }
     this.isLoading = true;
-    this.assembleRollupFromForm();
     await this.runValidate();
     if (Object.keys(this.errors).length > 0) {
       console.error("Record has errors", this.errors);
@@ -389,6 +401,15 @@ export default class RollupEditor extends LightningModal {
     const jobId = await saveRollupConfig({
       rollup: JSON.stringify(this.rollup)
     });
+
+    try {
+      window.sessionStorage.setItem(
+        "pending-" + this.rollup.developerName,
+        JSON.stringify(this.rollup)
+      );
+    } catch (err) {
+      console.error("Error setting session storage", err);
+    }
 
     this.close({
       action: "deloyStart",

--- a/dlrs/main/lwc/rollupEditorError/rollupEditorError.css
+++ b/dlrs/main/lwc/rollupEditorError/rollupEditorError.css
@@ -1,0 +1,3 @@
+div {
+  color: var(--lwc-colorTextError);
+}

--- a/dlrs/main/lwc/rollupEditorError/rollupEditorError.html
+++ b/dlrs/main/lwc/rollupEditorError/rollupEditorError.html
@@ -1,7 +1,5 @@
 <template>
-  <template if:true={hasErrors}>
-    <div style="color: red" for:each={errors} for:item="error" key={error}>
-      {error}
-    </div>
+  <template lwc:if={hasErrors}>
+    <div for:each={errors} for:item="error" key={error}>{error}</div>
   </template>
 </template>


### PR DESCRIPTION
# Critical Changes
LWC Wizard not correctly display next scheduled full calculation
LWC Wizard overwrites record for duplicated API Name

# Changes
Label and API Name should be limited to 40 characters and block save on error
Clarify messaging for Outstanding Scheduled Items
Fix typos
Edit screen shouldn't use collapsible sections except for Advanced
Path should reserve space to limit UI shift
Schedule Wizard: Improve title and Tagline
Schedule Wizard: Manage error states for poorly configured custom and for Schedule Items at max for org
If deployment fails, editor modal should be restored to edited state

# Issues Closed
#1457 
#1458
#1459 
#1460 
#1461 
#1462 
#1463 
#1464 
#1465 
#1466 
#1467 
