### PR TITLE
Datatable Column Filters

### DIFF
--- a/dlrs/main/lwc/manageRollups/manageRollups.html
+++ b/dlrs/main/lwc/manageRollups/manageRollups.html
@@ -32,7 +32,7 @@
           </lightning-layout>
           <lightning-datatable
             key-field="DeveloperName"
-            data={visibleRollups}
+            data={rollupList}
             columns={dtColumns}
             sorted-by={sortByField}
             sorted-direction={sortDirection}

--- a/dlrs/main/lwc/manageRollups/manageRollups.html
+++ b/dlrs/main/lwc/manageRollups/manageRollups.html
@@ -32,13 +32,14 @@
           </lightning-layout>
           <lightning-datatable
             key-field="DeveloperName"
-            data={rollupList}
+            data={visibleRollups}
             columns={dtColumns}
             sorted-by={sortByField}
             sorted-direction={sortDirection}
             onrowaction={rollupSelectHandler}
             hide-checkbox-column
             onsort={handleOnSort}
+            onheaderaction={handleHeaderAction}
           >
           </lightning-datatable>
           <lightning-spinner lwc:if={isLoading}></lightning-spinner>

--- a/dlrs/main/lwc/manageRollups/manageRollups.js
+++ b/dlrs/main/lwc/manageRollups/manageRollups.js
@@ -178,6 +178,20 @@ export default class ManageRollups extends NavigationMixin(LightningElement) {
             name: val
           });
         });
+
+        if (conf.fieldName in this.filters) {
+          const filteredValue = this.filters[conf.fieldName].value;
+
+          // check if currently filtered value is still relevant
+          if (availableValues.includes(filteredValue)) {
+            conf.actions.find(a => a.type === "filter" && a.name === "All").checked = false;
+            conf.actions.find(a => a.type === "filter" && a.name === filteredValue).checked = true;
+          } else {
+            // remove filter
+            delete this.filters[conf.fieldName];
+            conf.iconName = '';
+          }
+        }
       }
   
       return conf;

--- a/dlrs/main/lwc/manageRollups/manageRollups.js
+++ b/dlrs/main/lwc/manageRollups/manageRollups.js
@@ -68,19 +68,44 @@ export default class ManageRollups extends NavigationMixin(LightningElement) {
     {
       label: "Rollup Type",
       fieldName: "aggregateOperation",
-      sortable: true
+      sortable: true,
+      actions: [
+        { label: 'All', checked: true, name: 'All' },
+        { label: "Sum", checked: false, name: "Sum" },
+        { label: "Max", checked: false, name: "Max" },
+        { label: "Min", checked: false, name: "Min" },
+        { label: "Avg", checked: false, name: "Avg" },
+        { label: "Count", checked: false, name: "Count" },
+        { label: "Count Distinct", checked: false, name: "Count Distinct" },
+        { label: "Concatenate", checked: false, name: "Concatenate" },
+        { label: "Concatenate Distinct", checked: false, name: "Concatenate Distinct" },
+        { label: "First", checked: false, name: "First" },
+        { label: "Last", checked: false, name: "Last" }
+      ]
     },
     {
       label: "Calc Mode",
       fieldName: "calculationMode",
-      sortable: true
+      sortable: true,
+      actions: [
+        { label: 'All', checked: true, name: 'All' },
+        { label: "Watch for Changes and Process Later", checked: false, name: "Watch and Process" },
+        { label: "Realtime", checked: false, name: "Realtime" },
+        { label: "Invocable by Automation", checked: false, name: "Process Builder" },
+        { label: "Developer", checked: false, name: "Developer" }
+      ]
     },
     {
       label: "Active",
       fieldName: "active",
       initialWidth: 75,
       type: "boolean",
-      sortable: true
+      sortable: true,
+      actions: [
+        { label: 'All', checked: true, name: 'All' },
+        { label: 'Active', checked: false, name: 'checked' },
+        { label: 'Inactive', checked: false, name: 'unchecked' },
+      ]
     },
     {
       type: "button-icon",
@@ -109,12 +134,29 @@ export default class ManageRollups extends NavigationMixin(LightningElement) {
   searchFilter = "";
   isLoading = true;
   selectedRollup = undefined;
+  filters = {};
 
   connectedCallback() {
     this.refreshRollups();
     // Register error listener
     this.registerErrorListener();
     this.handleSubscribe();
+  }
+
+  get visibleRollups() {
+    return this.rollupList.filter(rollup => {
+      let filteredFieldNames = Object.keys(this.filters).filter(fieldName => this.filters[fieldName].value !== 'All');
+
+      return filteredFieldNames.every(fieldName => {
+        switch (this.filters[fieldName].type) {
+          case 'boolean':
+            return rollup[fieldName] === (this.filters[fieldName].value === 'checked' ? true : false)
+        
+          default:
+            return rollup[fieldName] === this.filters[fieldName].value
+        }
+      })
+    });
   }
 
   async refreshRollups() {
@@ -278,6 +320,18 @@ export default class ManageRollups extends NavigationMixin(LightningElement) {
     this.sortDirection = event.detail.sortDirection;
     // assign the latest attribute with the sorted column fieldName and sorted direction
     this.calcRollupList();
+  }
+
+  handleHeaderAction(event) {
+    let filters = {
+      ...this.filters,
+      [event.detail.columnDefinition.fieldName]: {
+        type: event.detail.columnDefinition.type,
+        value: event.detail.action.name
+      }
+    }
+
+    this.filters = filters;
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
# Changes
- Utilize LWC Datatable actions to filter by `Rollup Type`, `Calc Mode`, and `Active` in the primary datatable view
- Display the SLDS `utility:filterList` icon in the column header when a columns is actively being filtered
- The search filter continues to work in conjunction with the column filters

# Issues Closed
- #1449 