### PR TITLE
Fix duplicate detection issue by applying DML options with all-or-nothing behavior

### DIFF
--- a/dlrs/main/classes/RollupService.cls
+++ b/dlrs/main/classes/RollupService.cls
@@ -1670,13 +1670,10 @@ global with sharing class RollupService {
       // Run as current user to enforce sharing rules
       dml.DuplicateRuleHeader.runAsCurrentUser = true;
 
-      // Apply DmlOptions to each record
-      for (SObject record : masterRecords) {
-        record.setOptions(dml);
-      }
+      dml.OptAllOrNone = allOrNothing;
 
       try {
-        return Database.update(masterRecords, allOrNothing);
+        return Database.update(masterRecords, dml);
       } catch (DMLException e) {
         // Determine if the exception is due to parent record/s having been deleted
         Boolean throwException = true;
@@ -1699,6 +1696,7 @@ global with sharing class RollupService {
           return new List<Database.Saveresult>();
         }
         // Throw on as normal
+
         throw e;
       }
     }

--- a/dlrs/main/classes/RollupService.cls
+++ b/dlrs/main/classes/RollupService.cls
@@ -1661,6 +1661,20 @@ global with sharing class RollupService {
         masterRecords.set(outerIndex, masterRecords.get(indexOfMin));
         masterRecords.set(indexOfMin, temp);
       }
+      // Create DmlOptions instance
+      Database.DMLOptions dml = new Database.DMLOptions();
+
+      // Allow save even if duplicates are detected
+      dml.DuplicateRuleHeader.allowSave = true;
+
+      // Run as current user to enforce sharing rules
+      dml.DuplicateRuleHeader.runAsCurrentUser = true;
+
+      // Apply DmlOptions to each record
+      for (SObject record : masterRecords) {
+        record.setOptions(dml);
+      }
+
       try {
         return Database.update(masterRecords, allOrNothing);
       } catch (DMLException e) {


### PR DESCRIPTION



# Critical Changes

- Fixed an issue where `DUPLICATES_DETECTED` errors were incorrectly thrown during DML operations, even when duplicates were allowed.

# Changes

- Added `dml.OptAllOrNone = allOrNothing` to ensure proper handling of DML operations based on the `allOrNothing` flag.
- Adjusted `DMLOptions` to allow saving records with duplicates when `allowSave` is set.

# Issues Closed

- Resolved failures caused by duplicate rules during DML operations.
- Ensured consistent handling of duplicate records based on configured rules.


