### PR TITLE
Corrected September Spelling in the pages 

### DIFF
--- a/dlrs/main/pages/rollupscheduledcalculate.page
+++ b/dlrs/main/pages/rollupscheduledcalculate.page
@@ -121,7 +121,7 @@
 						<apex:selectOption itemValue="6" itemLabel="June" />
 						<apex:selectOption itemValue="7" itemLabel="July" />
 						<apex:selectOption itemValue="8" itemLabel="August" />
-						<apex:selectOption itemValue="9" itemLabel="Septemer" />
+						<apex:selectOption itemValue="9" itemLabel="September" />
 						<apex:selectOption itemValue="10" itemLabel="October" />
 						<apex:selectOption itemValue="11" itemLabel="November" />
 						<apex:selectOption itemValue="12" itemLabel="December" />

--- a/dlrs/main/pages/rollupscheduledcalculatemdt.page
+++ b/dlrs/main/pages/rollupscheduledcalculatemdt.page
@@ -122,7 +122,7 @@
 						<apex:selectOption itemValue="6" itemLabel="June" />
 						<apex:selectOption itemValue="7" itemLabel="July" />
 						<apex:selectOption itemValue="8" itemLabel="August" />
-						<apex:selectOption itemValue="9" itemLabel="Septemer" />
+						<apex:selectOption itemValue="9" itemLabel="September" />
 						<apex:selectOption itemValue="10" itemLabel="October" />
 						<apex:selectOption itemValue="11" itemLabel="November" />
 						<apex:selectOption itemValue="12" itemLabel="December" />


### PR DESCRIPTION
# Critical Changes
Corrected the spelling mistakes of september month in rollupscheduledcalculate.page and rollupscheduledcalculatemdt.page

# Changes
Renamed "Septemer" as  "September"

# Issues Closed
#1528 