### PR TITLE
Update README to correct "Release notes" link

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,7 +22,7 @@ Part of the Salesforce.org [Commons program](https://help.salesforce.com/s/artic
 
 - [Documentation](https://sfdo-community-sprints.github.io/DLRS-Documentation/)
 - [Install DLRS](https://sfdo-community-sprints.github.io/DLRS-Documentation/Installation/)
-- [Release notes](https://sfdo-community-sprints.github.io/DLRS-Documentation/Changelog/)
+- [Release notes](https://sfdo-community-sprints.github.io/DLRS-Documentation/ReleaseNotes/)
 
 ## Questions and Community Support
 


### PR DESCRIPTION
The README file's existing "Release notes" link to https://sfdo-community-sprints.github.io/DLRS-Documentation/Changelog/ is broken (404 error).

This PR just updates that link to the correct URL: https://sfdo-community-sprints.github.io/DLRS-Documentation/ReleaseNotes/