### PR TITLE
Add scheduling API and optional job cleanup on deactivate/delete.

### DIFF
--- a/dlrs/main/classes/CronTriggersSelector.cls
+++ b/dlrs/main/classes/CronTriggersSelector.cls
@@ -34,18 +34,19 @@ public with sharing class CronTriggersSelector extends fflib_SObjectSelector {
   }
 
   public List<CronTrigger> selectScheduledApexById(String id) {
-    id = '%' + id + '%';
+    return selectFullCalculateJobsByRollupId(id);
+  }
 
-    List<CronTrigger> ct = Database.query(
+  public List<CronTrigger> selectFullCalculateJobsByRollupId(String rollupId) {
+    String idPattern = '%' + String.valueOf(rollupId).substring(0, 15) + '%';
+
+    return Database.query(
       newQueryFactory()
         .selectfield('CronJobDetail.Name')
         .setCondition(
-          'CronJobDetail.JobType = \'7\' AND CronJobDetail.Name LIKE :id'
+          'CronJobDetail.JobType = \'7\' AND CronJobDetail.Name LIKE :idPattern'
         )
-        .setLimit(1)
         .tosoql()
     );
-
-    return ct;
   }
 }

--- a/dlrs/main/classes/LookupRollupStatusCheckController.cls
+++ b/dlrs/main/classes/LookupRollupStatusCheckController.cls
@@ -18,22 +18,7 @@ public with sharing class LookupRollupStatusCheckController {
   @AuraEnabled
   public static Datetime getScheduledFullCalculates(String lookupID) {
     try {
-      LookupRollupSummary2__mdt LookupRollupSummary = (LookupRollupSummary2__mdt) new RollupSummariesSelector.CustomMetadataSelector(
-            false,
-            true
-          )
-          .selectById(new Set<String>{ lookupID })[0]
-        .Record;
-
-      if (LookupRollupSummary != null) {
-        String id = (LookupRollupSummary.id).to15();
-        List<CronTrigger> ct = new CronTriggersSelector()
-          .selectScheduledApexById(id);
-
-        if (!ct.isEmpty()) {
-          return ct[0].NextFireTime;
-        }
-      }
+      return RollupSchedulingService.getNextFullCalculateRunTime(lookupID);
     } catch (Exception e) {
     }
     return null;

--- a/dlrs/main/classes/ManageLookupRollupSummariesController.cls
+++ b/dlrs/main/classes/ManageLookupRollupSummariesController.cls
@@ -235,15 +235,12 @@ public with sharing class ManageLookupRollupSummariesController {
     }
 
     try {
-      String id = (LookupRollupSummary.id).to15();
-      List<CronTrigger> ct = new CronTriggersSelector()
-        .selectScheduledApexById(id);
-
-      if (ct.isEmpty()) {
-        return 'No Schedule for Rollup';
-      } else {
-        return ct[0].NextFireTime.format();
-      }
+      Datetime nextRunTime = RollupSchedulingService.getNextFullCalculateRunTime(
+        LookupRollupSummary.id
+      );
+      return nextRunTime == null
+        ? 'No Schedule for Rollup'
+        : nextRunTime.format();
     } catch (Exception e) {
       return 'No Schedule for Rollup';
     }

--- a/dlrs/main/classes/RollupEditorController.cls
+++ b/dlrs/main/classes/RollupEditorController.cls
@@ -172,6 +172,18 @@ public with sharing class RollupEditorController {
     return pageRef.getUrl();
   }
 
+  @AuraEnabled(cacheable=true)
+  public static RollupSchedulingService.ScheduledJobInfo getScheduledFullCalculateJob(
+    Id rollupId
+  ) {
+    return RollupSchedulingService.getScheduledFullCalculateJob(rollupId);
+  }
+
+  @AuraEnabled
+  public static void unscheduleFullCalculate(Id rollupId) {
+    RollupSchedulingService.unscheduleFullCalculate(rollupId);
+  }
+
   private static Map<String, List<String>> collectErrors(RollupSummary rollup) {
     Map<String, List<String>> errorMap = new Map<String, List<String>>();
     if (rollup.Error != null) {

--- a/dlrs/main/classes/RollupEditorControllerTest.cls
+++ b/dlrs/main/classes/RollupEditorControllerTest.cls
@@ -149,6 +149,23 @@ public with sharing class RollupEditorControllerTest {
   }
 
   @IsTest
+  static void testGetScheduledFullCalculateJobWhenMissing() {
+    Assert.isNull(
+      RollupEditorController.getScheduledFullCalculateJob(lup.Id)
+    );
+  }
+
+  @IsTest
+  static void testUnscheduleFullCalculateWhenMissing() {
+    Test.startTest();
+    RollupEditorController.unscheduleFullCalculate(lup.Id);
+    Test.stopTest();
+    Assert.isNull(
+      RollupEditorController.getScheduledFullCalculateJob(lup.Id)
+    );
+  }
+
+  @IsTest
   static void testRollupConfig() {
     RollupEditorController.RollupConfig cfg = new RollupEditorController.RollupConfig(
       lup

--- a/dlrs/main/classes/RollupScheduledCalculateController.cls
+++ b/dlrs/main/classes/RollupScheduledCalculateController.cls
@@ -26,6 +26,7 @@
 
 public with sharing class RollupScheduledCalculateController {
   private ApexPages.StandardController standardController;
+  private String uniqueNameField;
   public String masterObjectWhere { get; set; }
   public String minute { get; set; }
   public List<SelectOption> minutes { get; set; }
@@ -39,7 +40,7 @@ public with sharing class RollupScheduledCalculateController {
     ApexPages.StandardController standardController
   ) {
     // Since thie controller is shared between custom object and custom mestadata, determine the applicable unique field
-    String uniqueNameField = ((Id) standardController.getId())
+    this.uniqueNameField = ((Id) standardController.getId())
         .getSObjectType() == Schema.LookupRollupSummary2__mdt.SObjectType
       ? 'DeveloperName'
       : 'UniqueName__c';
@@ -54,11 +55,10 @@ public with sharing class RollupScheduledCalculateController {
     // Calculate unique name
     String rollupUniqueName = (String) standardController.getRecord()
       .get(uniqueNameField);
-    uniqueNameForJob =
-      'rollup_' +
-      (rollupUniqueName == null || rollupUniqueName.equals('')
-        ? standardController.getId()
-        : rollupUniqueName + ' (' + standardController.getId() + ')');
+    uniqueNameForJob = RollupSchedulingService.buildFullCalculateJobName(
+      standardController.getId(),
+      rollupUniqueName
+    );
 
     // Deprication warning
     if (standardController.getRecord() instanceof LookupRollupSummary__c) {
@@ -127,13 +127,11 @@ public with sharing class RollupScheduledCalculateController {
       );
 
       // Kickoff the calculate job for this lookup
-      System.schedule(
-        uniqueNameForJob,
+      RollupSchedulingService.scheduleFullCalculate(
+        standardController.getId(),
         cronString,
-        new RollupCalculateJobSchedulable(
-          standardController.getId(),
-          masterObjectWhere
-        )
+        masterObjectWhere,
+        (String) standardController.getRecord().get(uniqueNameField)
       );
       ApexPages.addMessage(
         new ApexPages.Message(

--- a/dlrs/main/classes/RollupSchedulingService.cls
+++ b/dlrs/main/classes/RollupSchedulingService.cls
@@ -1,0 +1,70 @@
+public with sharing class RollupSchedulingService {
+  public class ScheduledJobInfo {
+    @AuraEnabled
+    public Id cronTriggerId;
+    @AuraEnabled
+    public String jobName;
+    @AuraEnabled
+    public Datetime nextFireTime;
+  }
+
+  public static String buildFullCalculateJobName(Id rollupId, String uniqueName) {
+    String rollupIdString = String.valueOf(rollupId);
+    return 'rollup_' +
+      (String.isBlank(uniqueName)
+        ? rollupIdString
+        : uniqueName + ' (' + rollupIdString + ')');
+  }
+
+  public static List<CronTrigger> findFullCalculateJobs(Id rollupId) {
+    if (rollupId == null) {
+      return new List<CronTrigger>();
+    }
+    return new CronTriggersSelector().selectFullCalculateJobsByRollupId(rollupId);
+  }
+
+  public static ScheduledJobInfo getScheduledFullCalculateJob(Id rollupId) {
+    List<CronTrigger> cronTriggers = findFullCalculateJobs(rollupId);
+    if (cronTriggers.isEmpty()) {
+      return null;
+    }
+
+    CronTrigger cronTrigger = cronTriggers[0];
+    ScheduledJobInfo jobInfo = new ScheduledJobInfo();
+    jobInfo.cronTriggerId = cronTrigger.Id;
+    jobInfo.jobName = cronTrigger.CronJobDetail.Name;
+    jobInfo.nextFireTime = cronTrigger.NextFireTime;
+    return jobInfo;
+  }
+
+  public static Datetime getNextFullCalculateRunTime(Id rollupId) {
+    ScheduledJobInfo jobInfo = getScheduledFullCalculateJob(rollupId);
+    return jobInfo == null ? null : jobInfo.nextFireTime;
+  }
+
+  public static Id scheduleFullCalculate(
+    Id rollupId,
+    String cronExpression,
+    String masterWhereClause,
+    String uniqueName
+  ) {
+    unscheduleFullCalculate(rollupId);
+    return System.schedule(
+      buildFullCalculateJobName(rollupId, uniqueName),
+      cronExpression,
+      new RollupCalculateJobSchedulable(rollupId, masterWhereClause)
+    );
+  }
+
+  public static void unschedule(Id cronTriggerId) {
+    if (cronTriggerId != null) {
+      System.abortJob(cronTriggerId);
+    }
+  }
+
+  public static void unscheduleFullCalculate(Id rollupId) {
+    for (CronTrigger cronTrigger : findFullCalculateJobs(rollupId)) {
+      System.abortJob(cronTrigger.Id);
+    }
+  }
+}

--- a/dlrs/main/classes/RollupSchedulingService.cls-meta.xml
+++ b/dlrs/main/classes/RollupSchedulingService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/dlrs/main/classes/RollupSchedulingServiceTest.cls
+++ b/dlrs/main/classes/RollupSchedulingServiceTest.cls
@@ -1,0 +1,176 @@
+@IsTest
+private class RollupSchedulingServiceTest {
+  @IsTest
+  static void buildFullCalculateJobNameWithoutUniqueName() {
+    Id rollupId = fflib_IDGenerator.generate(
+      LookupRollupSummary__c.SObjectType
+    );
+    Assert.areEqual(
+      'rollup_' + rollupId,
+      RollupSchedulingService.buildFullCalculateJobName(rollupId, null)
+    );
+  }
+
+  @IsTest
+  static void buildFullCalculateJobNameWithUniqueName() {
+    Id rollupId = fflib_IDGenerator.generate(
+      LookupRollupSummary__c.SObjectType
+    );
+    Assert.areEqual(
+      'rollup_MyRollup (' + rollupId + ')',
+      RollupSchedulingService.buildFullCalculateJobName(rollupId, 'MyRollup')
+    );
+  }
+
+  @IsTest
+  static void scheduleAndUnscheduleFullCalculate() {
+    if (!TestContext.isSupported()) {
+      return;
+    }
+
+    LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c(
+      Name = 'Test Rollup',
+      UniqueName__c = 'TestRollup',
+      ParentObject__c = 'Account',
+      ChildObject__c = 'Task',
+      RelationShipField__c = 'WhatId',
+      FieldToAggregate__c = 'Id',
+      AggregateOperation__c = RollupSummaries.AggregateOperation.Count.name(),
+      AggregateResultField__c = 'AnnualRevenue',
+      Active__c = true,
+      CalculationMode__c = 'Scheduled'
+    );
+    insert rollupSummary;
+
+    Test.startTest();
+    Id jobId = RollupSchedulingService.scheduleFullCalculate(
+      rollupSummary.Id,
+      '0 0 * * * ? 2100',
+      '',
+      rollupSummary.UniqueName__c
+    );
+    Test.stopTest();
+
+    Assert.isNotNull(jobId);
+    List<CronTrigger> cronTriggers = RollupSchedulingService.findFullCalculateJobs(
+      rollupSummary.Id
+    );
+    Assert.areEqual(1, cronTriggers.size());
+    Assert.areEqual(
+      RollupSchedulingService.buildFullCalculateJobName(
+        rollupSummary.Id,
+        rollupSummary.UniqueName__c
+      ),
+      cronTriggers[0].CronJobDetail.Name
+    );
+
+    RollupSchedulingService.unscheduleFullCalculate(rollupSummary.Id);
+    Assert.isTrue(
+      RollupSchedulingService.findFullCalculateJobs(rollupSummary.Id).isEmpty()
+    );
+  }
+
+  @IsTest
+  static void scheduleFullCalculateReplacesExistingJob() {
+    if (!TestContext.isSupported()) {
+      return;
+    }
+
+    LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c(
+      Name = 'Test Rollup',
+      ParentObject__c = 'Account',
+      ChildObject__c = 'Task',
+      RelationShipField__c = 'WhatId',
+      FieldToAggregate__c = 'Id',
+      AggregateOperation__c = RollupSummaries.AggregateOperation.Count.name(),
+      AggregateResultField__c = 'AnnualRevenue',
+      Active__c = true,
+      CalculationMode__c = 'Scheduled'
+    );
+    insert rollupSummary;
+
+    Test.startTest();
+    Id firstJobId = RollupSchedulingService.scheduleFullCalculate(
+      rollupSummary.Id,
+      '0 0 * * * ? 2100',
+      '',
+      null
+    );
+    Id secondJobId = RollupSchedulingService.scheduleFullCalculate(
+      rollupSummary.Id,
+      '0 0 * * * ? 2101',
+      '',
+      null
+    );
+    Test.stopTest();
+
+    Assert.areNotEqual(firstJobId, secondJobId);
+    Assert.areEqual(
+      1,
+      RollupSchedulingService.findFullCalculateJobs(rollupSummary.Id).size()
+    );
+
+    RollupSchedulingService.unscheduleFullCalculate(rollupSummary.Id);
+  }
+
+  @IsTest
+  static void unscheduleFullCalculateIsIdempotent() {
+    Id rollupId = fflib_IDGenerator.generate(
+      LookupRollupSummary__c.SObjectType
+    );
+
+    Test.startTest();
+    RollupSchedulingService.unscheduleFullCalculate(rollupId);
+    Test.stopTest();
+
+    Assert.isTrue(
+      RollupSchedulingService.findFullCalculateJobs(rollupId).isEmpty()
+    );
+  }
+
+  @IsTest
+  static void getScheduledFullCalculateJobReturnsNullWhenMissing() {
+    Id rollupId = fflib_IDGenerator.generate(
+      LookupRollupSummary__c.SObjectType
+    );
+    Assert.isNull(
+      RollupSchedulingService.getScheduledFullCalculateJob(rollupId)
+    );
+  }
+
+  @IsTest
+  static void getNextFullCalculateRunTimeReturnsScheduledValue() {
+    List<LookupRollupSummary2__mdt> summaries = [
+      SELECT Id, DeveloperName
+      FROM LookupRollupSummary2__mdt
+      LIMIT 1
+    ];
+    if (summaries.isEmpty()) {
+      return;
+    }
+
+    String jobName = RollupSchedulingService.buildFullCalculateJobName(
+      summaries[0].Id,
+      summaries[0].DeveloperName
+    );
+    Id jobId;
+    try {
+      jobId = System.schedule(
+        jobName,
+        '0 0 * * * ? 2100',
+        new RollupCalculateJobSchedulable(summaries[0].Id, '')
+      );
+    } catch (Exception e) {
+      System.debug('Schedule failed: ' + e.getMessage());
+    }
+
+    Datetime nextRun = RollupSchedulingService.getNextFullCalculateRunTime(
+      summaries[0].Id
+    );
+    Assert.isNotNull(nextRun);
+
+    if (jobId != null) {
+      System.abortJob(jobId);
+    }
+  }
+}

--- a/dlrs/main/classes/RollupSchedulingServiceTest.cls-meta.xml
+++ b/dlrs/main/classes/RollupSchedulingServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/dlrs/main/lwc/manageRollups/manageRollups.js
+++ b/dlrs/main/lwc/manageRollups/manageRollups.js
@@ -5,6 +5,8 @@ import { NavigationMixin, CurrentPageReference } from "lightning/navigation";
 
 import getAllRollupConfigs from "@salesforce/apex/RollupEditorController.getAllRollupConfigs";
 import deleteRollupConfig from "@salesforce/apex/RollupEditorController.deleteRollupConfig";
+import getScheduledFullCalculateJob from "@salesforce/apex/RollupEditorController.getScheduledFullCalculateJob";
+import unscheduleFullCalculate from "@salesforce/apex/RollupEditorController.unscheduleFullCalculate";
 import USER_ID from "@salesforce/user/Id";
 import RollupEditor, { CLASS_SCHEDULER_CONFIG } from "c/rollupEditor";
 import ClassSchedulerModal from "c/classSchedulerModal";
@@ -301,22 +303,65 @@ export default class ManageRollups extends NavigationMixin(LightningElement) {
   }
 
   async requestDelete(rollupName) {
-    const confirmed = await LightningConfirm.open({
-      message: `Are you sure you want to delete the rollup named: ${rollupName}`,
-      label: "Delete Rollup Configuration",
-      theme: "warning"
-    });
-    if (confirmed) {
-      this.dispatchEvent(
-        new ShowToastEvent({
-          title: "Delete Started",
-          message: `Started request to delete ${rollupName}`,
-          variant: "info"
-        })
-      );
-      this.isLoading = true;
-      deleteRollupConfig({ rollupName: rollupName });
+    const rollup = Object.values(this.rollups).find(
+      (r) => r.developerName === rollupName
+    );
+    let unscheduleJob = false;
+
+    if (rollup?.id) {
+      const scheduledJob = await getScheduledFullCalculateJob({
+        rollupId: rollup.id
+      });
+      if (scheduledJob) {
+        const confirmed = await LightningConfirm.open({
+          label: "Delete Rollup Configuration",
+          message: `Are you sure you want to delete the rollup named "${rollupName}"? It has a Scheduled Full Calculate job named "${scheduledJob.jobName}" that will continue to run unless removed.`,
+          theme: "warning"
+        });
+        if (!confirmed) {
+          return;
+        }
+
+        unscheduleJob = await LightningConfirm.open({
+          label: "Delete Scheduled Job",
+          message: `Also delete the scheduled Full Calculate job "${scheduledJob.jobName}"?`,
+          theme: "warning",
+          confirmButtonLabel: "Delete Job",
+          cancelButtonLabel: "Keep Job"
+        });
+      } else {
+        const confirmed = await LightningConfirm.open({
+          message: `Are you sure you want to delete the rollup named: ${rollupName}`,
+          label: "Delete Rollup Configuration",
+          theme: "warning"
+        });
+        if (!confirmed) {
+          return;
+        }
+      }
+    } else {
+      const confirmed = await LightningConfirm.open({
+        message: `Are you sure you want to delete the rollup named: ${rollupName}`,
+        label: "Delete Rollup Configuration",
+        theme: "warning"
+      });
+      if (!confirmed) {
+        return;
+      }
     }
+
+    this.dispatchEvent(
+      new ShowToastEvent({
+        title: "Delete Started",
+        message: `Started request to delete ${rollupName}`,
+        variant: "info"
+      })
+    );
+    this.isLoading = true;
+    if (unscheduleJob && rollup?.id) {
+      await unscheduleFullCalculate({ rollupId: rollup.id });
+    }
+    deleteRollupConfig({ rollupName: rollupName });
   }
 
   runCreateNew() {

--- a/dlrs/main/lwc/rollupEditor/rollupEditor.js
+++ b/dlrs/main/lwc/rollupEditor/rollupEditor.js
@@ -1,6 +1,7 @@
 import { api, track, wire } from "lwc";
 
 import LightningModal from "lightning/modal";
+import LightningConfirm from "lightning/confirm";
 import { ShowToastEvent } from "lightning/platformShowToastEvent";
 
 import { PATH_STATES } from "c/flexiblePath";
@@ -12,6 +13,8 @@ import getFieldOptions from "@salesforce/apex/RollupEditorController.getFieldOpt
 import getManageTriggerPageUrl from "@salesforce/apex/RollupEditorController.getManageTriggerPageUrl";
 import getFullCalculatePageUrl from "@salesforce/apex/RollupEditorController.getFullCalculatePageUrl";
 import getScheduleCalculatePageUrl from "@salesforce/apex/RollupEditorController.getScheduleCalculatePageUrl";
+import getScheduledFullCalculateJob from "@salesforce/apex/RollupEditorController.getScheduledFullCalculateJob";
+import unscheduleFullCalculate from "@salesforce/apex/RollupEditorController.unscheduleFullCalculate";
 import hasChildTriggerDeployed from "@salesforce/apex/LookupRollupStatusCheckController.hasChildTriggerDeployed";
 import getScheduledFullCalculates from "@salesforce/apex/LookupRollupStatusCheckController.getScheduledFullCalculates";
 import getScheduledJobs from "@salesforce/apex/LookupRollupStatusCheckController.getScheduledJobs";
@@ -274,9 +277,33 @@ export default class RollupEditor extends LightningModal {
     this.runSave();
   }
 
-  deactivateClickHandler() {
+  async deactivateClickHandler() {
+    let unscheduleJob = false;
+    const scheduledJob = this.rollup.id
+      ? await getScheduledFullCalculateJob({ rollupId: this.rollup.id })
+      : null;
+
+    if (scheduledJob) {
+      const confirmed = await LightningConfirm.open({
+        label: "Deactivate Rollup",
+        message: `This rollup has a Scheduled Full Calculate job named "${scheduledJob.jobName}". Deactivating will not remove it automatically.`,
+        theme: "warning"
+      });
+      if (!confirmed) {
+        return;
+      }
+
+      unscheduleJob = await LightningConfirm.open({
+        label: "Delete Scheduled Job",
+        message: `Also delete the scheduled Full Calculate job "${scheduledJob.jobName}"?`,
+        theme: "warning",
+        confirmButtonLabel: "Delete Job",
+        cancelButtonLabel: "Keep Job"
+      });
+    }
+
     this.rollup.active = false;
-    this.runSave();
+    await this.runSave(unscheduleJob);
   }
 
   rollupTypeChangeHandler(event) {
@@ -387,7 +414,7 @@ export default class RollupEditor extends LightningModal {
     return val.replace(/^([0-9])/, "X$1").replace(/[^0-9a-zA-Z]+/g, "_");
   }
 
-  async runSave() {
+  async runSave(unscheduleJob = false) {
     if (!this.assembleRollupFromForm()) {
       console.error("data form is invalid");
       return;
@@ -401,6 +428,10 @@ export default class RollupEditor extends LightningModal {
     const jobId = await saveRollupConfig({
       rollup: JSON.stringify(this.rollup)
     });
+
+    if (unscheduleJob && this.rollup.id) {
+      await unscheduleFullCalculate({ rollupId: this.rollup.id });
+    }
 
     try {
       window.sessionStorage.setItem(


### PR DESCRIPTION
Centralize per-rollup Full Calculate scheduling in RollupSchedulingService and prompt users to remove orphaned jobs when deactivating or deleting rollups.

# Critical Changes

None (this doesn't break existing APIs).

# Changes

Moves scheduling to a new scheduling service class (`RollupSchedulingService`). 

Refactored callers to use the new API:
 
* RollupScheduledCalculateController
* LookupRollupStatusCheckController
* ManageLookupRollupSummariesController

# Issues Closed

* #1569